### PR TITLE
Fix `adjoint(::Circuit)` function

### DIFF
--- a/src/Circuit.jl
+++ b/src/Circuit.jl
@@ -92,7 +92,6 @@ Base.iterate(circuit::Circuit, state = fill(1, lanes(circuit))) = begin
             lane, i = x
             circuit.lanes[lane][i]
         end)
-
     if isempty(candidates)
         return nothing
     end

--- a/src/Circuit.jl
+++ b/src/Circuit.jl
@@ -92,6 +92,7 @@ Base.iterate(circuit::Circuit, state = fill(1, lanes(circuit))) = begin
             lane, i = x
             circuit.lanes[lane][i]
         end)
+
     if isempty(candidates)
         return nothing
     end
@@ -134,9 +135,9 @@ circuit * circuit' == circuit' * circuit == I(n)
 """
 Base.adjoint(circuit::Circuit) = begin
     lanes = [
-        [
-            Element{Gate}(data(el), [laneid => length(circuit.lanes[laneid]) - p + 1 for (laneid, p) in el.priority]) for el in lane
-        ] for lane in circuit.lanes
+        reverse([
+            Element{Gate}(data(el)', [laneid => length(circuit.lanes[laneid]) - p + 1 for (laneid, p) in el.priority]) for el in lane
+        ]) for lane in circuit.lanes
     ]
 
     Circuit(lanes)


### PR DESCRIPTION
Fix #12. 

### Summary
The elements inside each lane had to be reversed for the `iterate` function to work as expected. Also, we now take the adjoint of each gate in order to correctly do the adjoint of the circuit. 