### PR TITLE
Fix `draw()` function crash on `Sd` gate type

### DIFF
--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -123,7 +123,7 @@ function draw_block(label = ""; top::Bool = false, bottom::Bool = false)
 
         # label
         fontsize(16)
-        text(label, valign = :middle, halign = :center)
+        text(label, Point(0, 0), valign = :middle, halign = :center)
     end 50 50
 end
 


### PR DESCRIPTION
Fix #16.

### Summary
Added the argument `Point(0, 0)`, necessary for the `Luxor.text` function when the label is `::LaTeXStrings.LaTeXString`.