### PR TITLE
Remove artifact gates from appearing in `draw` function

### DIFF
--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -49,8 +49,13 @@ end
 
 function draw(gate::Gate; top::Bool = false, bottom::Bool = false, kwargs...)
     n = (length ∘ lanes)(gate)
+
     if n == 1
-        draw_block(; top = top, bottom = bottom, kwargs...)
+        if gate isa I
+            draw(I; kwargs...)
+        else
+            draw_block(; top = top, bottom = bottom, kwargs...)
+        end
     else
         a, b = extrema(lanes(gate))
         n = b - a + 1
@@ -62,6 +67,7 @@ draw(::I) = draw(I)
 function draw(::Type{I}; background = nothing)
     @drawsvg begin
         (background !== nothing) && Luxor.background(background)
+
         origin()
         line(Point(-25, 0), Point(25, 0), action = :stroke)
     end 50 50
@@ -107,6 +113,8 @@ end
 function draw_block(label = ""; top::Bool = false, bottom::Bool = false, background = nothing)
     @drawsvg begin
         (background !== nothing) && Luxor.background(background)
+
+        println("label: $label")
         origin()
 
         # lane wire

--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -67,7 +67,6 @@ draw(::I) = draw(I)
 function draw(::Type{I}; background = nothing)
     @drawsvg begin
         (background !== nothing) && Luxor.background(background)
-
         origin()
         line(Point(-25, 0), Point(25, 0), action = :stroke)
     end 50 50
@@ -113,8 +112,6 @@ end
 function draw_block(label = ""; top::Bool = false, bottom::Bool = false, background = nothing)
     @drawsvg begin
         (background !== nothing) && Luxor.background(background)
-
-        println("label: $label")
         origin()
 
         # lane wire


### PR DESCRIPTION
Fix #20.

### Summary
The `draw(::Gate)` function called `draw_block()` even for gates that are the identity (`Quac.I`), this caused the function to draw empty gates when there should only be a connecting wire.

### Example
Now the visualization works as expected,
```julia
julia> circ = Circuit(4); push!(circ, Sd(1)); push!(circ, CX(2,4)); push!(circ, CZ(1,4)); push!(circ, X(1))
julia> circ
```

Output:
![image](https://user-images.githubusercontent.com/61060572/210330584-26577923-e1f9-4afa-9c88-13b388605a0c.png)

