### PR TITLE
Refactor `Gate` type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ SimpleWeightedGraphs = "47aef6b3-ad0c-573a-a1e2-d07658019622"
 
 [compat]
 Combinatorics = "1.0.0"
+LaTeXStrings = "1.3"
 Luxor = "3.5"
 MathTeXEngine = "0.5"
 Requires = "1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.3"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
+LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Luxor = "ae8d54c2-7ccd-5906-9d76-62fc9837b5bc"
 MathTeXEngine = "0a4f8689-d25c-4efe-a92b-7142dfc1aa53"

--- a/docs/src/api/gates.md
+++ b/docs/src/api/gates.md
@@ -44,6 +44,7 @@ julia> Diagonal{Float32}(gate)
 ```
 
 ```@docs
+Operator
 Gate
 ```
 

--- a/docs/src/api/gates.md
+++ b/docs/src/api/gates.md
@@ -43,39 +43,6 @@ julia> Diagonal{Float32}(gate)
   ⋅   -1.0
 ```
 
-## `Gate` trait
-
-All gates follow the `Gate` interface.
-
-1. Set the parent abstract type to `Gate`. Your struct should have a `lane` field of type `Int`.
-
-```julia
-struct CustomGate <: Gate
-    lane::Int
-end
-```
-
-- If your gate is a multi-qubit gate, then `lane` is of type `NTuple{N,Int}`.
-- If your gate is a parametric gate, then inherit from `ParametricGate`.
-
-2. Specify the type of the adjoint of your `CustomGate`. If your gate is hermitian, then it is itself.
-
-```julia
-Base.adjoint(::Type{CustomGate}) = CustomGate
-```
-
-3. Provide the representations of `CustomGate`. At least the `Matrix` representation should be provided.
-
-```julia
-Matrix{T}(_::CustomGate) where {T} = Matrix{T}([...])
-```
-
-- If the gate accepts other representations, you can implement them. For example, the $Z$ gate allows a `Diagonal`  representation.
-
-```julia
-Diagonal{T}(_::Z) where {T} = Diagonal{T}([1, -1])
-```
-
 ```@docs
 Gate
 ```

--- a/src/Algorithms.jl
+++ b/src/Algorithms.jl
@@ -16,7 +16,7 @@ function QFT(n::Int)
 
         for control in target+1:n
             m = control - target
-            push!(circuit, CRz(control, target, (θ = 2π / 2^m,)))
+            push!(circuit, CRz(control, target, θ = 2π / 2^m))
         end
     end
 

--- a/src/Array.jl
+++ b/src/Array.jl
@@ -89,7 +89,14 @@ end
 @eval Array{T}(::Type{G}) where {T,G<:Gate} = Array{T,2 * length(operator(G))}(G)
 @eval Array{T}(g::G) where {T,G<:Gate} = Array{T,2 * length(operator(G))}(isparametric(operator(G)) ? g : G)
 
-Array{T,4}(::Type{<:Gate{Swap}}) where {T} = Array{T}([1; 0;; 0; 0;;; 0; 0;; 1; 0;;;; 0; 1;; 0; 0;;; 0; 0;; 0; 1])
+# NOTE multidimensional `Array` literal concatenation was introduced in 1.7
+# TODO clean code when we stop supporting Julia 1.6
+Array{T,4}(::Type{<:Gate{Swap}}) where {T} =
+    if VERSION >= v"1.7"
+        Array{T}([1; 0;; 0; 0;;; 0; 0;; 1; 0;;;; 0; 1;; 0; 0;;; 0; 0;; 0; 1])
+    else
+        reshape(Matrix{T}(Gate{Swap}), (2, 2, 2, 2))
+    end
 
 Array{T}(::Type{Gate{C}}) where {T,C<:Control} =
     Array{T,2 * length(C)}(reshape(Matrix{T}(Gate{C}), fill(2, 2 * length(C))...))

--- a/src/Array.jl
+++ b/src/Array.jl
@@ -1,5 +1,5 @@
 import Base: Matrix, Array
-import LinearAlgebra: Diagonal, eigvals, eigvecs, eigen
+import LinearAlgebra: Diagonal, diag, eigvals, eigvecs, eigen
 using LinearAlgebra: Eigen, LinearAlgebra
 
 # preferred representation
@@ -10,11 +10,11 @@ arraytype(::T) where {T<:Gate} = arraytype(T)
 arraytype(::Type{<:Gate}) = Array{T} where {T}
 
 for G in [I, Z, S, Sd, T, Td, Rz]
-    @eval arraytype(::Type{$G}) = Diagonal
+    @eval arraytype(::Type{<:Gate{$G}}) = Diagonal
 end
 
 for G in [X, Y, H, Rx, Ry]
-    @eval arraytype(::Type{$G}) = Matrix
+    @eval arraytype(::Type{<:Gate{$G}}) = Matrix
 end
 
 # TODO arraytype(::Type{T}) where {T<:Control} = arraytype(op(T)) == Diagonal ? Diagonal : Matrix
@@ -22,59 +22,59 @@ end
 Matrix(x::Gate) = Matrix{ComplexF32}(x)
 Matrix(::Type{T}) where {T<:Gate} = Matrix{ComplexF32}(T)
 
-for G in [I, X, Y, Z, H, S, Sd, T, Td, Swap]
-    @eval Matrix{T}(_::$G) where {T} = Matrix{T}($G)
+for Op in [I, X, Y, Z, H, S, Sd, T, Td, Swap]
+    @eval Matrix{T}(::G) where {T,G<:Gate{$Op}} = Matrix{T}(G)
 end
 
-Matrix{T}(::Type{I}) where {T} = Matrix{T}(LinearAlgebra.I, 2, 2)
-Matrix{T}(::Type{X}) where {T} = Matrix{T}([0 1; 1 0])
-Matrix{T}(::Type{Y}) where {T} = Matrix{T}([0 -1im; 1im 0])
-Matrix{T}(::Type{Z}) where {T} = Matrix{T}([1 0; 0 -1])
-Matrix{T}(::Type{H}) where {T} = Matrix{T}([1 1; 1 -1] ./ sqrt(2))
-Matrix{T}(::Type{S}) where {T} = Matrix{T}([1 0; 0 1im])
-Matrix{T}(::Type{Sd}) where {T} = Matrix{T}([1 0; 0 -1im])
-Matrix{F}(::Type{T}) where {F} = Matrix{F}([1 0; 0 cispi(1 // 4)])
-Matrix{F}(::Type{Td}) where {F} = Matrix{F}([1 0; 0 cispi(-1 // 4)])
+Matrix{T}(::Type{<:Gate{I}}) where {T} = Matrix{T}(LinearAlgebra.I, 2, 2)
+Matrix{T}(::Type{<:Gate{X}}) where {T} = Matrix{T}([0 1; 1 0])
+Matrix{T}(::Type{<:Gate{Y}}) where {T} = Matrix{T}([0 -1im; 1im 0])
+Matrix{T}(::Type{<:Gate{Z}}) where {T} = Matrix{T}([1 0; 0 -1])
+Matrix{T}(::Type{<:Gate{H}}) where {T} = Matrix{T}([1 1; 1 -1] ./ sqrt(2))
+Matrix{T}(::Type{<:Gate{S}}) where {T} = Matrix{T}([1 0; 0 1im])
+Matrix{T}(::Type{<:Gate{Sd}}) where {T} = Matrix{T}([1 0; 0 -1im])
+Matrix{F}(::Type{<:Gate{T}}) where {F} = Matrix{F}([1 0; 0 cispi(1 // 4)])
+Matrix{F}(::Type{<:Gate{Td}}) where {F} = Matrix{F}([1 0; 0 cispi(-1 // 4)])
 
-Matrix{T}(::Type{Swap}) where {T} = Matrix{T}([1 0 0 0; 0 0 1 0; 0 1 0 0; 0 0 0 1])
+Matrix{T}(::Type{<:Gate{Swap}}) where {T} = Matrix{T}([1 0 0 0; 0 0 1 0; 0 1 0 0; 0 0 0 1])
 
-Matrix{T}(g::Rx) where {T} = Matrix{T}([
-    cos(g[:θ] / 2) -1im*sin(g[:θ] / 2)
-    -1im*sin(g[:θ] / 2) cos(g[:θ] / 2)
+Matrix{T}(g::G) where {T,G<:Gate{Rx}} = Matrix{T}([
+    cos(g.θ / 2) -1im*sin(g.θ / 2)
+    -1im*sin(g.θ / 2) cos(g.θ / 2)
 ])
-Matrix{T}(g::Ry) where {T} = Matrix{T}([
-    cos(g[:θ] / 2) -sin(g[:θ] / 2)
-    sin(g[:θ] / 2) cos(g[:θ] / 2)
+Matrix{T}(g::G) where {T,G<:Gate{Ry}} = Matrix{T}([
+    cos(g.θ / 2) -sin(g.θ / 2)
+    sin(g.θ / 2) cos(g.θ / 2)
 ])
-Matrix{T}(g::Rz) where {T} = Matrix{T}([1 0; 0 cis(g[:θ])])
+Matrix{T}(g::G) where {T,G<:Gate{Rz}} = Matrix{T}([1 0; 0 cis(g.θ)])
 
-Matrix{T}(g::U2) where {T} = 1 / sqrt(2) * Matrix{T}([
-    1 -cis(g[:λ])
-    cis(g[:ϕ]) cis(g[:ϕ] + g[:λ])
+Matrix{T}(g::G) where {T,G<:Gate{U2}} = 1 / sqrt(2) * Matrix{T}([
+    1 -cis(g.λ)
+    cis(g.ϕ) cis(g.ϕ + g.λ)
 ])
-Matrix{T}(g::U3) where {T} = Matrix{T}([
-    cos(g[:θ] / 2) -cis(g[:λ])*sin(g[:θ] / 2)
-    cis(g[:ϕ])*sin(g[:θ] / 2) cis(g[:ϕ] + g[:λ])*cos(g[:θ] / 2)
+Matrix{T}(g::G) where {T,G<:Gate{U3}} = Matrix{T}([
+    cos(g.θ / 2) -cis(g.λ)*sin(g.θ / 2)
+    cis(g.ϕ)*sin(g.θ / 2) cis(g.ϕ + g.λ)*cos(g.θ / 2)
 ])
 
-function Matrix{T}(::Type{Control{G}}) where {T,G}
-    n = lanes(Control{G})
-    t = lanes(G)
+function Matrix{T}(::Type{Gate{Op}}) where {T,Op<:Control}
+    n = length(Op)
+    t = length(targettype(Op))
 
     M = Matrix{T}(LinearAlgebra.I, 2^n, 2^n)
 
-    M[(2^n-2^t+1):end, (2^n-2^t+1):end] = Matrix{T}(G)
+    M[(2^n-2^t+1):end, (2^n-2^t+1):end] = Matrix{T}(Gate{targettype(Op)})
 
     return M
 end
 
-function Matrix{T}(g::Control) where {T}
+function Matrix{T}(g::Gate{<:Control}) where {T}
     n = (length ∘ lanes)(g)
     t = (length ∘ target)(g)
 
     M = Matrix{T}(LinearAlgebra.I, 2^n, 2^n)
 
-    M[(2^n-2^t+1):end, (2^n-2^t+1):end] = Matrix{T}(op(g))
+    M[(2^n-2^t+1):end, (2^n-2^t+1):end] = Matrix{T}(Gate{targettype(operator(g))}(target(g)...; parameters(g)...))
 
     return M
 end
@@ -82,29 +82,44 @@ end
 Array(x::Gate) = Array{ComplexF32}(x)
 Array(::Type{T}) where {T<:Gate} = Array{ComplexF32}(T)
 
-Array{T}(::Type{Swap}) where {T} = Array{T,4}(Swap)
-Array{T,4}(::Type{Swap}) where {T} = Array{T}([1; 0;; 0; 0;;; 0; 0;; 1; 0;;;; 0; 1;; 0; 0;;; 0; 0;; 0; 1])
+for Op in [I, X, Y, Z, H, S, Sd, T, Td, Swap]
+    @eval Array{T}(::G) where {T,G<:Gate{$Op}} = Array{T}(G)
+end
 
-Array{T}(::Type{G}) where {T,G<:Control} = Array{T,2 * lanes(G)}(reshape(Matrix{T}(G), fill(2, 2 * lanes(G))...))
-Array{T}(g::G) where {T,G<:Control} = Array{T,2 * lanes(G)}(reshape(Matrix{T}(g), fill(2, 2 * lanes(G))...))
+@eval Array{T}(::Type{G}) where {T,G<:Gate} = Array{T,2 * length(operator(G))}(G)
+@eval Array{T}(g::G) where {T,G<:Gate} = Array{T,2 * length(operator(G))}(isparametric(operator(G)) ? g : G)
+
+Array{T,4}(::Type{<:Gate{Swap}}) where {T} = Array{T}([1; 0;; 0; 0;;; 0; 0;; 1; 0;;;; 0; 1;; 0; 0;;; 0; 0;; 0; 1])
+
+Array{T}(::Type{Gate{C}}) where {T,C<:Control} =
+    Array{T,2 * length(C)}(reshape(Matrix{T}(Gate{C}), fill(2, 2 * length(C))...))
+Array{T}(g::Gate{C}) where {T,C<:Control} = Array{T,2 * length(C)}(reshape(Matrix{T}(g), fill(2, 2 * length(C))...))
 
 # diagonal matrices
 # NOTE efficient multiplication due to no memory swap needed: plain element-wise multiplication
 Diagonal(x::Gate) = Diagonal{ComplexF32}(x)
 Diagonal(::Type{T}) where {T<:Gate} = Diagonal{ComplexF32}(T)
 
-for G in [I, Z, S, Sd, T, Td]
-    @eval Diagonal{T}(_::$G) where {T} = Diagonal{T}($G)
+for Op in [I, Z, S, Sd, T, Td]
+    @eval Diagonal{T}(::Gate{$Op}) where {T} = Diagonal{T}(Gate{$Op})
 end
 
-Diagonal{T}(::Type{I}) where {T} = Diagonal{T}(LinearAlgebra.I, 2)
-Diagonal{T}(::Type{Z}) where {T} = Diagonal{T}([1, -1])
-Diagonal{T}(::Type{S}) where {T} = Diagonal{T}([1, 1im])
-Diagonal{T}(::Type{Sd}) where {T} = Diagonal{T}([1, -1im])
-Diagonal{F}(::Type{T}) where {F} = Diagonal{F}([1, cispi(1 // 4)])
-Diagonal{T}(::Type{Td}) where {T} = Diagonal{T}([1, cispi(-1 // 4)])
+Diagonal{T}(::Type{<:Gate{I}}) where {T} = Diagonal{T}(LinearAlgebra.I, 2)
+Diagonal{T}(::Type{<:Gate{Z}}) where {T} = Diagonal{T}([1, -1])
+Diagonal{T}(::Type{<:Gate{S}}) where {T} = Diagonal{T}([1, 1im])
+Diagonal{T}(::Type{<:Gate{Sd}}) where {T} = Diagonal{T}([1, -1im])
+Diagonal{F}(::Type{<:Gate{T}}) where {F} = Diagonal{F}([1, cispi(1 // 4)])
+Diagonal{T}(::Type{<:Gate{Td}}) where {T} = Diagonal{T}([1, cispi(-1 // 4)])
 
-Diagonal{T}(g::Rz) where {T} = Diagonal{T}([1 0; 0 cis(g[:θ])])
+Diagonal{T}(g::Gate{Rz}) where {T} = Diagonal{T}([1, cis(g.θ)])
+
+Diagonal{T}(::Type{Gate{Op}}) where {T,Op<:Control} =
+    Diagonal{T}([fill(one(T), 2^length(Op) - 2^length(targettype(Op)))..., diag(Diagonal{T}(Gate{targettype(Op)}))...])
+
+Diagonal{T}(g::Gate{Op}) where {T,Op<:Control} = Diagonal{T}([
+    fill(one(T), 2^length(Op) - 2^length(targettype(Op)))...,
+    diag(Diagonal{T}(Gate{targettype(Op)}(target(g)...; parameters(g)...)))...,
+])
 
 # permutational matrices (diagonal + permutation)
 # Permutation(x::Gate) = Permutation{ComplexF32}(x)

--- a/src/Gate.jl
+++ b/src/Gate.jl
@@ -69,7 +69,7 @@ const Phase = Union{I,Z,S,Sd,T,Td,Rz}
 
 An `Operator` located at some `lanes` and configured with some `parameters`.
 """
-struct Gate{Op,N,Params}
+struct Gate{Op<:Operator,N,Params}
     lanes::NTuple{N,Int}
     parameters::Params
 

--- a/src/Gate.jl
+++ b/src/Gate.jl
@@ -96,6 +96,17 @@ Base.length(::Type{Gate{Op}}) where {Op} = length(Op)
 operator(::Type{<:Gate{Op}}) where {Op} = Op
 operator(::Gate{Op}) where {Op} = operator(Gate{Op})
 
+function Base.summary(io::IO, gate::Gate)
+    flatten = Iterators.flatten
+    map = Iterators.map
+
+    Op = operator(gate)
+    Args = join(flatten((lanes(gate), map(x -> "$(x[1])=$(x[2])", pairs(parameters(gate))))), ",")
+    print(io, "$Op($Args)")
+end
+
+Base.show(io::IO, ::MIME"text/plain", gate::Gate) = summary(io, gate)
+
 parameters(g::Gate) = g.parameters
 parameters(::Type{<:Gate{Op}}) where {Op} = parameters(Op)
 Base.propertynames(::Type{<:Gate{Op}}) where {Op} = (keys(parameters(Op))...,)

--- a/src/Gate.jl
+++ b/src/Gate.jl
@@ -8,6 +8,11 @@ export CX, CY, CZ, CRx, CRy, CRz
 export control, target, operator
 export Pauli, Phase
 
+"""
+    Operator
+
+Parent type of quantum operators.
+"""
 abstract type Operator{Params<:NamedTuple} end
 
 # NOTE useful type piracy
@@ -19,13 +24,100 @@ const StaticOperator = Operator{NamedTuple{(),Tuple{}}}
 parameters(::Type{<:Operator{Params}}) where {Params} = Params
 isparametric(::Type{T}) where {T<:Operator} = parameters(T) !== NamedTuple{(),Tuple{}}
 
+"""
+    I(lane)
+
+The ``σ_0`` Pauli matrix gate.
+
+# Note
+
+Due to name clashes with `LinearAlgebra.I`, `Quac.I` is not exported by default.
+"""
+abstract type I <: StaticOperator end
+
+"""
+    X(lane)
+
+The ``σ_1`` Pauli matrix gate.
+"""
+abstract type X <: StaticOperator end
+
+"""
+    Y(lane)
+
+The ``σ_2`` Pauli matrix gate.
+"""
+abstract type Y <: StaticOperator end
+
+"""
+    Z(lane)
+
+The ``σ_3`` Pauli matrix gate.
+"""
+abstract type Z <: StaticOperator end
+
+"""
+    H(lane)
+
+The Hadamard gate.
+"""
+abstract type H <: StaticOperator end
+
+"""
+    S(lane)
+
+The ``S`` gate or ``\\frac{π}{2}`` rotation around Z-axis.
+"""
+abstract type S <: StaticOperator end
+
+"""
+    Sd(lane)
+
+The ``S^\\dagger`` gate or ``-\\frac{π}{2}`` rotation around Z-axis.
+"""
+abstract type Sd <: StaticOperator end
+
+"""
+    T(lane)
+
+The ``T`` gate or ``\\frac{π}{4}`` rotation around Z-axis.
+"""
+abstract type T <: StaticOperator end
+
+"""
+    Td(lane)
+
+The ``T^\\dagger`` gate or ``-\\frac{π}{4}`` rotation around Z-axis.
+"""
+abstract type Td <: StaticOperator end
+
 for Op in [:I, :X, :Y, :Z, :H, :S, :Sd, :T, :Td]
-    @eval abstract type $Op <: StaticOperator end
     @eval Base.length(::Type{$Op}) = 1
 end
 
+"""
+    Rx(lane, θ)
+
+The ``\\theta`` rotation around the X-axis gate.
+"""
 abstract type Rx <: Operator{NamedTuple{(:θ,),Tuple{Float64}}} end
+
+"""
+    Ry(lane, θ)
+
+The ``\\theta`` rotation around the Y-axis gate.
+"""
 abstract type Ry <: Operator{NamedTuple{(:θ,),Tuple{Float64}}} end
+
+"""
+    Rz(lane, θ)
+
+The ``\\theta`` rotation around the Z-axis gate.
+
+# Notes
+
+  - The `U1` gate is an alias of `Rz`.
+"""
 abstract type Rz <: Operator{NamedTuple{(:θ,),Tuple{Float64}}} end
 
 for Op in [:Rx, :Ry, :Rz]
@@ -34,15 +126,35 @@ end
 
 const U1 = Rz
 
+"""
+    U2(lane, ϕ, λ)
+
+The ``U2`` gate.
+"""
 abstract type U2 <: Operator{NamedTuple{(:ϕ, :λ),Tuple{Float64,Float64}}} end
 Base.length(::Type{U2}) = 1
 
+"""
+    U3(lane, θ, ϕ, λ)
+
+The ``U3`` gate.
+"""
 abstract type U3 <: Operator{NamedTuple{(:θ, :ϕ, :λ),Tuple{Float64,Float64,Float64}}} end
 Base.length(::Type{U3}) = 1
 
+"""
+    Swap(lane1, lane2)
+
+The SWAP gate.
+"""
 abstract type Swap <: StaticOperator end
 Base.length(::Type{Swap}) = 2
 
+"""
+    Control(lane, op::Gate)
+
+A controlled gate.
+"""
 abstract type Control{Op<:Operator} <: Operator{NamedTuple{(:target,),Tuple{Operator}}} end
 Base.length(::Type{Control{T}}) where {T<:Operator} = 1 + length(T)
 parameters(::Type{Control{Op}}) where {Op} = parameters(Op)

--- a/src/Gate.jl
+++ b/src/Gate.jl
@@ -113,10 +113,10 @@ Base.rand(::Type{Op}) where {Op<:Operator} = rand(parameters(Op))
 Base.rand(::Type{Gate{Op}}, lanes::Integer...) where {Op} = Gate{Op}(lanes...; rand(Op)...)
 
 # Gate{Control}
-op(::Type{Op}) where {Op<:Operator} = Op
-op(::Type{Control{Op}}) where {Op} = Op
-op(::Type{Control{Op}}) where {Op<:Control} = op(Op)
-op(::Type{<:Gate{Op}}) where {Op} = op(Op)
+targettype(::Type{Op}) where {Op<:Operator} = Op
+targettype(::Type{Control{Op}}) where {Op} = Op
+targettype(::Type{Control{Op}}) where {Op<:Control} = targettype(Op)
+targettype(::Type{<:Gate{Op}}) where {Op} = targettype(Op)
 
-control(g::G) where {G<:Gate{<:Control}} = lanes(g)[1:end-length(op(G))]
-target(g::G) where {G<:Gate{<:Control}} = lanes(g)[end-length(op(G))+1:end]
+control(g::G) where {G<:Gate{<:Control}} = lanes(g)[1:end-length(targettype(G))]
+target(g::G) where {G<:Gate{<:Control}} = lanes(g)[end-length(targettype(G))+1:end]

--- a/src/Gate.jl
+++ b/src/Gate.jl
@@ -82,11 +82,11 @@ struct Gate{Op<:Operator,N,Params}
 end
 
 # constructor aliases
-for Op in [I, X, Y, Z, H, S, Sd, T, Td, U2, U3, Swap]
-    @eval $(Symbol(Op))(lanes...; params...) = Gate{$Op}(lanes...; params...)
+for Op in [:I, :X, :Y, :Z, :H, :S, :Sd, :T, :Td, :U2, :U3, :Rx, :Ry, :Rz, :Swap]
+    @eval $Op(lanes...; params...) = Gate{$Op}(lanes...; params...)
 end
 
-# TODO Gate{Control} constructor
+Control{Op}(lanes...; params...) where {Op} = Gate{Control{Op}}(lanes...; params...)
 
 lanes(g::Gate) = g.lanes
 Base.length(::Type{Gate{Op}}) where {Op} = length(Op)

--- a/src/Gate.jl
+++ b/src/Gate.jl
@@ -6,6 +6,7 @@ export Rx, Ry, Rz, U1, U2, U3
 export Control, Swap
 export CX, CY, CZ, CRx, CRy, CRz
 export control, target, operator
+export Pauli, Phase
 
 abstract type Operator{Params<:NamedTuple} end
 

--- a/src/Gate.jl
+++ b/src/Gate.jl
@@ -1,6 +1,3 @@
-import Base: adjoint, rand
-using Base: front, tail
-
 export Gate
 export lanes
 export X, Y, Z, H, S, Sd, T, Td

--- a/src/Gate.jl
+++ b/src/Gate.jl
@@ -84,7 +84,7 @@ struct Gate{Op,N,Params}
 end
 
 # constructor aliases
-for Op in filter(x -> x isa DataType, subtypes(Operator))
+for Op in [I, X, Y, Z, H, S, Sd, T, Td, U2, U3, Swap]
     @eval $(Symbol(Op))(lanes...; params...) = Gate{$Op}(lanes...; params...)
 end
 

--- a/src/Gate.jl
+++ b/src/Gate.jl
@@ -90,6 +90,7 @@ for Op in [:I, :X, :Y, :Z, :H, :S, :Sd, :T, :Td, :U2, :U3, :Rx, :Ry, :Rz, :Swap]
 end
 
 Control{Op}(lanes...; params...) where {Op} = Gate{Control{Op}}(lanes...; params...)
+Control(lane, op::Gate{Op}) where {Op} = Gate{Control{Op}}(lane, lanes(op)...; parameters(op)...)
 
 lanes(g::Gate) = g.lanes
 Base.length(::Type{Gate{Op}}) where {Op} = length(Op)

--- a/src/Gate.jl
+++ b/src/Gate.jl
@@ -102,6 +102,8 @@ Base.propertynames(::Type{<:Gate{Op}}) where {Op} = (keys(parameters(Op))...,)
 Base.propertynames(::G) where {G<:Gate{Op}} where {Op} = propertynames(G)
 Base.getproperty(g::Gate{Op}, i::Symbol) where {Op} = i ∈ propertynames(g) ? parameters(g)[i] : getfield(g, i)
 
+Base.adjoint(::Type{<:Gate{Op}}) where {Op} = Gate{adjoint(Op)}
+Base.adjoint(::Type{Gate{Op,N,P}}) where {Op,N,P} = Gate{adjoint(Op),N,P}
 Base.adjoint(g::Gate{Op}) where {Op} = Gate{Op'}(lanes(g)...; [key => -val for (key, val) in pairs(parameters(g))]...)
 
 # NOTE useful type piracy

--- a/src/Gate.jl
+++ b/src/Gate.jl
@@ -10,6 +10,9 @@ export Pauli, Phase
 
 abstract type Operator{Params<:NamedTuple} end
 
+# NOTE useful type piracy
+Base.keys(::Type{<:NamedTuple{K}}) where {K} = K
+
 # `Operator` with no parameters
 const StaticOperator = Operator{NamedTuple{(),Tuple{}}}
 
@@ -95,7 +98,7 @@ operator(::Gate{Op}) where {Op} = operator(Gate{Op})
 
 parameters(g::Gate) = g.parameters
 parameters(::Type{<:Gate{Op}}) where {Op} = parameters(Op)
-Base.propertynames(::Type{Gate{Op}}) where {Op} = (first(parameters(Op).parameters)...,)
+Base.propertynames(::Type{<:Gate{Op}}) where {Op} = (keys(parameters(Op))...,)
 Base.propertynames(::G) where {G<:Gate{Op}} where {Op} = propertynames(G)
 Base.getproperty(g::Gate{Op}, i::Symbol) where {Op} = i ∈ propertynames(g) ? parameters(g)[i] : getfield(g, i)
 

--- a/src/Gate.jl
+++ b/src/Gate.jl
@@ -90,10 +90,11 @@ Control{Op}(lanes...; params...) where {Op} = Gate{Control{Op}}(lanes...; params
 
 lanes(g::Gate) = g.lanes
 Base.length(::Type{Gate{Op}}) where {Op} = length(Op)
-operator(::Gate{Op}) where {Op} = Op
+operator(::Type{<:Gate{Op}}) where {Op} = Op
+operator(::Gate{Op}) where {Op} = operator(Gate{Op})
 
 parameters(g::Gate) = g.parameters
-parameters(::Type{Gate{Op}}) where {Op} = parameters(Op)
+parameters(::Type{<:Gate{Op}}) where {Op} = parameters(Op)
 Base.propertynames(::Type{Gate{Op}}) where {Op} = (first(parameters(Op).parameters)...,)
 Base.propertynames(::G) where {G<:Gate{Op}} where {Op} = propertynames(G)
 Base.getproperty(g::Gate{Op}, i::Symbol) where {Op} = i ∈ propertynames(g) ? parameters(g)[i] : getfield(g, i)

--- a/src/Gate.jl
+++ b/src/Gate.jl
@@ -61,7 +61,7 @@ Base.adjoint(::Type{Control{Op}}) where {Op} = Control{adjoint(Op)}
 
 # operator sets
 const Pauli = Union{I,X,Y,Z}
-const Phase = Union{Z,S,Sd,T,Td,Rz}
+const Phase = Union{I,Z,S,Sd,T,Td,Rz}
 
 """
     Gate{Operator}(lanes...; parameters...)

--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -1,5 +1,15 @@
 using Luxor
 using MathTeXEngine
+using LaTeXStrings
+
+texname(::Type{Op}) where {Op<:Operator} = LaTeXString(String(nameof(Op)))
+
+texname(::Type{Sd}) = L"S^\dagger"
+texname(::Type{Td}) = L"T^\dagger"
+
+texname(::Type{Rx}) = L"R_X"
+texname(::Type{Ry}) = L"R_Y"
+texname(::Type{Rz}) = L"R_Z"
 
 function draw end
 export draw

--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -18,7 +18,7 @@ function draw(circuit::Circuit; kwargs...)
     n = lanes(circuit)
 
     if isempty(circuit)
-        return vcat([draw(I; kwargs...) for _ in 1:n]...)
+        return vcat([draw(Gate{I}(lane); kwargs...) for lane in 1:n]...)
     end
 
     # split moments if gates overlap in 1D
@@ -48,7 +48,7 @@ function draw(circuit::Circuit; kwargs...)
         (min, max) = extrema(mapreduce(lanes, ∪, moment))
         moment = [map(I, filter(<(min), 1:n))..., moment..., map(I, filter(>(max), 1:n))...]
 
-        mapreduce(x->draw(x; kwargs...), vcat, moment)
+        mapreduce(x -> draw(x; kwargs...), vcat, moment)
     end
 end
 
@@ -57,24 +57,21 @@ function Base.show(io::IO, ::MIME"image/svg+xml", circuit::Circuit)
     print(io, svgstring())
 end
 
-function draw(gate::Gate; top::Bool = false, bottom::Bool = false, kwargs...)
-    n = (length ∘ lanes)(gate)
-
-    if n == 1
-        if gate isa I
-            draw(I; kwargs...)
-        else
-            draw_block(; top = top, bottom = bottom, kwargs...)
-        end
-    else
-        a, b = extrema(lanes(gate))
-        n = b - a + 1
-        vcat(draw_block(; top = top, kwargs...), fill(draw_multiblock_mid(; kwargs...), (n - 2))..., draw_block(; bottom = bottom, kwargs...))
-    end
+function draw(gate::Gate{Op,1,P}; kwargs...) where {Op,P}
+    draw_block(; top = false, bottom = false)
 end
 
-draw(::I) = draw(I)
-function draw(::Type{I}; background = nothing)
+function draw(gate::Gate{Op,N,P}; kwargs...) where {Op,N,P}
+    a, b = extrema(lanes(gate))
+    n = b - a + 1
+    vcat(
+        draw_block(; top = true, bottom = false, kwargs...),
+        fill(draw_multiblock_mid(; kwargs...), (n - 2))...,
+        draw_block(; top = false, bottom = true, kwargs...),
+    )
+end
+
+function draw(::Gate{I,1,NamedTuple{(),Tuple{}}}; background = nothing)
     @drawsvg begin
         (background !== nothing) && Luxor.background(background)
         origin()
@@ -82,18 +79,16 @@ function draw(::Type{I}; background = nothing)
     end 50 50
 end
 
-for (T, N) in [(X, "X"), (Y, "Y"), (Z, "Z"), (H, "H"), (S, "S"), (Sd, L"S^\dagger"), (T, "T"), (Td, L"T^\dagger")]
-    @eval begin
-        draw(::$T; kwargs...) = draw($T; kwargs...)
-        draw(::Type{$T}; kwargs...) = draw_block($N; kwargs...)
-    end
+for Op in [X, Y, Z, H, S, Sd, T, Td, Rx, Ry, Rz]
+    @eval draw(::Gate{$Op,1,P}; kwargs...) where {P} = draw_block(texname($Op); kwargs...)
 end
 
-function draw(gate::Control; kwargs...)
+function draw(gate::Gate{<:Control}; kwargs...)
     c = control(gate)
     t = target(gate)
     r = range(extrema(lanes(gate))...)
 
+    # TODO Control{Swap}
     @assert length(t) == 1
 
     vcat(
@@ -106,7 +101,12 @@ function draw(gate::Control; kwargs...)
                 draw_cross(; kwargs...)
             end for lane in r if lane < only(t)
         ]...,
-        draw(op(gate); top = !any(<(only(t)), c), bottom = !any(>(only(t)), c), kwargs...),
+        draw(
+            Gate{targettype(operator(gate))}(target(gate)...; parameters(gate)...);
+            top = !any(<(only(t)), c),
+            bottom = !any(>(only(t)), c),
+            kwargs...,
+        ),
         [
             if lane == last(r)
                 draw_copy(:bottom; kwargs...)

--- a/test/Array_test.jl
+++ b/test/Array_test.jl
@@ -1,0 +1,140 @@
+@testset "Array" begin
+    using Quac: I
+
+    @testset "Matrix" begin
+        for Op in [
+            I,
+            X,
+            Y,
+            Z,
+            H,
+            S,
+            Sd,
+            T,
+            Td,
+            Swap,
+            Control{I},
+            Control{Control{I}},
+            Control{Control{Control{I}}},
+            Control{Swap},
+            Control{Control{Swap}},
+            Control{Control{Control{Swap}}},
+        ]
+            @test Matrix(Gate{Op}) isa Matrix{ComplexF32}
+            @test size(Matrix(Gate{Op})) == (2^length(Op), 2^length(Op))
+        end
+
+        for Op in [
+            I,
+            X,
+            Y,
+            Z,
+            H,
+            S,
+            Sd,
+            T,
+            Td,
+            Rx,
+            Ry,
+            Rz,
+            Swap,
+            Control{I},
+            Control{Control{I}},
+            Control{Control{Control{I}}},
+            Control{Rx},
+            Control{Control{Rx}},
+            Control{Control{Control{Rx}}},
+            Control{Swap},
+            Control{Control{Swap}},
+            Control{Control{Control{Swap}}},
+        ]
+            N = length(Op)
+            gate = Gate{Op}(1:N...; rand(Op)...)
+            @test Matrix(gate) isa Matrix{ComplexF32}
+            @test size(Matrix(gate)) == (2^length(Op), 2^length(Op))
+        end
+    end
+
+    @testset "Diagonal" begin
+        using LinearAlgebra: Diagonal, diag
+
+        for Op in [I, Z, S, Sd, T, Td, Control{Z}, Control{Control{Z}}, Control{Control{Control{Z}}}]
+            @test Diagonal(Gate{Op}) isa Diagonal{ComplexF32}
+        end
+
+        for Op in [
+            I,
+            Z,
+            S,
+            Sd,
+            T,
+            Td,
+            Rz,
+            Control{Z},
+            Control{Control{Z}},
+            Control{Control{Control{Z}}},
+            Control{Rz},
+            Control{Control{Rz}},
+            Control{Control{Control{Rz}}},
+        ]
+            gate = Gate{Op}(1:length(Op)...; rand(Op)...)
+            @test Diagonal(gate) isa Diagonal{ComplexF32}
+            @test size(Matrix(gate)) == (2^length(Op), 2^length(Op))
+        end
+    end
+
+    @testset "Array" begin
+        for Op in [
+            I,
+            X,
+            Y,
+            Z,
+            H,
+            S,
+            Sd,
+            T,
+            Td,
+            Swap,
+            Control{I},
+            Control{Control{I}},
+            Control{Control{Control{I}}},
+            Control{Swap},
+            Control{Control{Swap}},
+            Control{Control{Control{Swap}}},
+        ]
+            N = length(Op) * 2
+            @test Array(Gate{Op}) isa Array{ComplexF32,N}
+            @test size(Array(Gate{Op})) == tuple(fill(2, N)...)
+        end
+
+        for Op in [
+            I,
+            X,
+            Y,
+            Z,
+            H,
+            S,
+            Sd,
+            T,
+            Td,
+            Rx,
+            Ry,
+            Rz,
+            Swap,
+            Control{I},
+            Control{Control{I}},
+            Control{Control{Control{I}}},
+            Control{Rx},
+            Control{Control{Rx}},
+            Control{Control{Control{Rx}}},
+            Control{Swap},
+            Control{Control{Swap}},
+            Control{Control{Control{Swap}}},
+        ]
+            N = length(Op)
+            gate = Gate{Op}(1:N...; rand(Op)...)
+            @test Array(gate) isa Array{ComplexF32,2N}
+            @test size(Array(gate)) == tuple(fill(2, 2N)...)
+        end
+    end
+end

--- a/test/Circuit_test.jl
+++ b/test/Circuit_test.jl
@@ -1,6 +1,6 @@
 using Quac: Circuit, lanes, X
 
-@testset "Circuit" verbose = true begin
+@testset "Circuit" begin
     @testset "lanes" begin
         for n in [0, 1, 2, 4]
             @test lanes(Circuit(n)) == n

--- a/test/Gate_test.jl
+++ b/test/Gate_test.jl
@@ -1,0 +1,319 @@
+@testset "Gate" begin
+    using Quac: I
+
+    @testset "Base.length" begin
+        for Op in [
+            I,
+            X,
+            Y,
+            Z,
+            H,
+            S,
+            Sd,
+            T,
+            Td,
+            Rx,
+            Ry,
+            Rz,
+            Swap,
+            Control{I},
+            Control{Control{I}},
+            Control{Control{Control{I}}},
+            Control{Swap},
+            Control{Control{Swap}},
+            Control{Control{Control{Swap}}},
+        ]
+            @test length(Gate{Op}) === length(Op)
+        end
+    end
+
+    @testset "Constructor" begin
+        for Op in [I, X, Y, Z, H, S, Sd, T, Td, Rx, Ry, Rz]
+            @test Gate{Op}(range(1, length = length(Op))...; rand(parameters(Op))...) !== nothing
+        end
+    end
+
+    @testset "Constructor aliases" begin
+        for Op in [
+            I,
+            X,
+            Y,
+            Z,
+            H,
+            S,
+            Sd,
+            T,
+            Td,
+            Rx,
+            Ry,
+            Rz,
+            Swap,
+            Control{I},
+            Control{Control{I}},
+            Control{Control{Control{I}}},
+            Control{Rx},
+            Control{Control{Rx}},
+            Control{Control{Control{Rx}}},
+            Control{Swap},
+            Control{Control{Swap}},
+            Control{Control{Control{Swap}}},
+        ]
+            N = length(Op)
+            P = parameters(Op)
+            @test Op(1:N...; rand(P)...) isa Gate{Op,N,P}
+        end
+    end
+
+    @testset "lanes" begin
+        for Op in [
+            I,
+            X,
+            Y,
+            Z,
+            H,
+            S,
+            Sd,
+            T,
+            Td,
+            Rx,
+            Ry,
+            Rz,
+            U2,
+            U3,
+            Swap,
+            Control{I},
+            Control{Control{I}},
+            Control{Control{Control{I}}},
+            Control{Rx},
+            Control{Control{Rx}},
+            Control{Control{Control{Rx}}},
+            Control{Swap},
+            Control{Control{Swap}},
+            Control{Control{Control{Swap}}},
+        ]
+            @test lanes(Gate{Op}(1:length(Op)...; rand(parameters(Op))...)) === tuple(1:length(Op)...)
+        end
+    end
+
+    @testset "operator" begin
+        for Op in [
+            I,
+            X,
+            Y,
+            Z,
+            H,
+            S,
+            Sd,
+            T,
+            Td,
+            Rx,
+            Ry,
+            Rz,
+            U2,
+            U3,
+            Swap,
+            Control{I},
+            Control{Control{I}},
+            Control{Control{Control{I}}},
+            Control{Rx},
+            Control{Control{Rx}},
+            Control{Control{Control{Rx}}},
+            Control{Swap},
+            Control{Control{Swap}},
+            Control{Control{Control{Swap}}},
+        ]
+            # NOTE `operator(Gate{Op})` is implied
+            @test operator(Gate{Op}(1:length(Op)...; rand(parameters(Op))...)) === Op
+        end
+    end
+
+    @testset "parameters" begin
+        for Op in [
+            I,
+            X,
+            Y,
+            Z,
+            H,
+            S,
+            Sd,
+            T,
+            Td,
+            Rx,
+            Ry,
+            Rz,
+            Swap,
+            Control{I},
+            Control{Control{I}},
+            Control{Control{Control{I}}},
+            Control{Rx},
+            Control{Control{Rx}},
+            Control{Control{Control{Rx}}},
+            Control{Swap},
+            Control{Control{Swap}},
+            Control{Control{Control{Swap}}},
+        ]
+            @test parameters(Gate{Op}) === parameters(Op)
+
+            params = rand(parameters(Op))
+            @test parameters(Gate{Op}(1:length(Op)...; params...)) === params
+        end
+    end
+
+    @testset "adjoint" begin
+        for Op in [
+            I,
+            X,
+            Y,
+            Z,
+            H,
+            S,
+            Sd,
+            T,
+            Td,
+            Rx,
+            Ry,
+            Rz,
+            Swap,
+            Control{I},
+            Control{Control{I}},
+            Control{Control{Control{I}}},
+            Control{Rx},
+            Control{Control{Rx}},
+            Control{Control{Control{Rx}}},
+            Control{Swap},
+            Control{Control{Swap}},
+            Control{Control{Control{Swap}}},
+        ]
+            @test adjoint(Gate{Op}) === Gate{adjoint(Op)}
+        end
+
+        # `adjoint(::Gate)` with no parameters
+        for Op in [I, X, Y, Z, H, S, Sd, T, Td, Swap, Control{I}, Control{Control{I}}, Control{Control{Control{I}}}]
+            @test adjoint(Gate{Op}(1:length(Op)...)) === Gate{adjoint(Op)}(1:length(Op)...)
+        end
+
+        # `adjoint(::Gate)` with parameters
+        for Op in [Rx, Ry, Rz, Control{Rx}, Control{Control{Rx}}, Control{Control{Control{Rx}}}]
+            params = rand(parameters(Op))
+            @test adjoint(Gate{Op}(1:length(Op)...; params...)) ===
+                  Gate{adjoint(Op)}(1:length(Op)...; [key => -val for (key, val) in pairs(params)]...)
+        end
+    end
+
+    @testset "Base.rand" begin
+        for Op in [
+            I,
+            X,
+            Y,
+            Z,
+            H,
+            S,
+            Sd,
+            T,
+            Td,
+            Rx,
+            Ry,
+            Rz,
+            Swap,
+            Control{I},
+            Control{Control{I}},
+            Control{Control{Control{I}}},
+            Control{Rx},
+            Control{Control{Rx}},
+            Control{Control{Control{Rx}}},
+            Control{Swap},
+            Control{Control{Swap}},
+            Control{Control{Control{Swap}}},
+        ]
+            N = length(Op)
+            P = parameters(Op)
+            @test rand(Gate{Op}, 1:N...) isa Gate{Op,N,P}
+        end
+    end
+
+    @testset "Base.propertynames" begin
+        for Op in [
+            I,
+            X,
+            Y,
+            Z,
+            H,
+            S,
+            Sd,
+            T,
+            Td,
+            Rx,
+            Ry,
+            Rz,
+            Swap,
+            Control{I},
+            Control{Control{I}},
+            Control{Control{Control{I}}},
+            Control{Rx},
+            Control{Control{Rx}},
+            Control{Control{Control{Rx}}},
+            Control{Swap},
+            Control{Control{Swap}},
+            Control{Control{Control{Swap}}},
+        ]
+            @test keys(parameters(Op)) ⊆ propertynames(Gate{Op})
+
+            N = length(Op)
+            @test keys(parameters(Op)) ⊆ propertynames(rand(Gate{Op}, 1:N...))
+        end
+    end
+
+    @testset "Base.getproperty" begin
+        # TODO
+    end
+
+    @testset "targettype" begin
+        using Quac: targettype
+
+        for Op in [I, X, Y, Z, H, S, Sd, T, Td, Rx, Ry, Rz, Swap]
+            @test targettype(Gate{Op}) === Op
+        end
+
+        for Op in [Control{I}, Control{Control{I}}, Control{Control{Control{I}}}]
+            @test targettype(Gate{Op}) === I
+        end
+    end
+
+    @testset "control" begin
+        for Op in [I, X, Y, Z, H, S, Sd, T, Td, Rx, Ry, Rz, Swap]
+            @test_throws MethodError control(rand(Gate{Op}, 1:length(Op)...))
+        end
+
+        for Op in [I, Rx, Swap]
+            N = length(Op)
+
+            M = length(Control{Op})
+            @test control(rand(Gate{Control{Op}}, 1:M...)) === (1:(M-N)...,)
+
+            M = length(Control{Control{Op}})
+            @test control(rand(Gate{Control{Control{Op}}}, 1:M...)) === (1:(M-N)...,)
+
+            M = length(Control{Control{Control{Op}}})
+            @test control(rand(Gate{Control{Control{Control{Op}}}}, 1:M...)) === (1:(M-N)...,)
+        end
+    end
+
+    @testset "target" begin
+        for Op in [I, X, Y, Z, H, S, Sd, T, Td, Rx, Ry, Rz, Swap]
+            @test_throws MethodError target(rand(Gate{Op}, 1:length(Op)...))
+        end
+
+        for Op in [I, Rx, Swap]
+            N = length(Op)
+
+            M = length(Control{Op})
+            @test target(rand(Gate{Control{Op}}, 1:M...)) === ((M-N)+1:M...,)
+
+            M = length(Control{Control{Op}})
+            @test target(rand(Gate{Control{Control{Op}}}, 1:M...)) === ((M-N)+1:M...,)
+
+            M = length(Control{Control{Control{Op}}})
+            @test target(rand(Gate{Control{Control{Control{Op}}}}, 1:M...)) === ((M-N)+1:M...,)
+        end
+    end
+end

--- a/test/Operator_test.jl
+++ b/test/Operator_test.jl
@@ -45,6 +45,35 @@
         @test adjoint(Control{Control{Control{S}}}) === Control{Control{Control{Sd}}}
     end
 
+    @testset "Base.rand" begin
+        for Op in [
+            I,
+            X,
+            Y,
+            Z,
+            H,
+            S,
+            Sd,
+            T,
+            Td,
+            Rx,
+            Ry,
+            Rz,
+            Swap,
+            Control{I},
+            Control{Control{I}},
+            Control{Control{Control{I}}},
+            Control{Rx},
+            Control{Control{Rx}},
+            Control{Control{Control{Rx}}},
+            Control{Swap},
+            Control{Control{Swap}},
+            Control{Control{Control{Swap}}},
+        ]
+            @test rand(Op) isa parameters(Op)
+        end
+    end
+
     @testset "Operator sets" begin
         @testset "Pauli" begin
             for Op in [I, X, Y, Z]

--- a/test/Operator_test.jl
+++ b/test/Operator_test.jl
@@ -1,0 +1,69 @@
+@testset "Operator" begin
+    using Quac: I, StaticOperator
+
+    NoParameters = parameters(StaticOperator)
+
+    @testset "isparametric" begin
+        for Op in [I, X, Y, Z, H, S, Sd, T, Td, Swap, Control{I}, Control{Control{I}}, Control{Control{Control{I}}}]
+            @test isparametric(Op) == false
+        end
+
+        for Op in [Rx, Ry, Rz, U2, U3, Control{Rx}, Control{Control{Rx}}, Control{Control{Control{Rx}}}]
+            @test isparametric(Op) == true
+        end
+    end
+
+    @testset "parameters" begin
+        @test parameters(Control{U2}) === parameters(U2)
+        @test parameters(Control{Control{U2}}) === parameters(U2)
+        @test parameters(Control{Control{Control{U2}}}) === parameters(U2)
+    end
+
+    @testset "Base.length" begin
+        for Op in [I, X, Y, Z, H, S, Sd, T, Td, Rx, Ry, Rz]
+            @test length(Op) == 1
+        end
+
+        @test length(Swap) == 2
+
+        @test length(Control{I}) == 2
+        @test length(Control{Control{I}}) == 3
+        @test length(Control{Control{Control{I}}}) == 4
+    end
+
+    @testset "Base.adjoint" begin
+        for Op in [I, X, Y, Z, H, Rx, Ry, Rz, Swap, Control{I}, Control{Control{I}}, Control{Control{Control{I}}}]
+            @test adjoint(Op) === Op
+        end
+
+        @test adjoint(S) == Sd
+        @test adjoint(Sd) == S
+        @test adjoint(T) == Td
+        @test adjoint(Td) == T
+        @test adjoint(Control{S}) === Control{Sd}
+        @test adjoint(Control{Control{S}}) === Control{Control{Sd}}
+        @test adjoint(Control{Control{Control{S}}}) === Control{Control{Control{Sd}}}
+    end
+
+    @testset "Operator sets" begin
+        @testset "Pauli" begin
+            for Op in [I, X, Y, Z]
+                @test Op <: Pauli
+            end
+
+            for Op in [Rx, Ry, Rz, S, Sd, T, Td, H, Swap, Control{I}, Control{Control{I}}, Control{Control{Control{I}}}]
+                @test !(Op <: Pauli)
+            end
+        end
+
+        @testset "Phase" begin
+            for Op in [I, Z, S, Sd, T, Td, Rz]
+                @test Op <: Phase
+            end
+
+            for Op in [X, Y, H, Rx, Ry, Swap, Control{I}, Control{Control{I}}, Control{Control{Control{I}}}]
+                @test !(Op <: Phase)
+            end
+        end
+    end
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Quac
 
 @testset "Unit tests" verbose = true begin
     include("Operator_test.jl")
+    include("Gate_test.jl")
     include("Circuit_test.jl")
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using Quac
 @testset "Unit tests" verbose = true begin
     include("Operator_test.jl")
     include("Gate_test.jl")
+    include("Array_test.jl")
     include("Circuit_test.jl")
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Test
 using Quac
 
 @testset "Unit tests" verbose = true begin
+    include("Operator_test.jl")
     include("Circuit_test.jl")
 end
 


### PR DESCRIPTION
Now `Gate` type is decoupled into 2 types:
- `Operator`: An abstract type that parametrically contains the number of qubits it targets and the name and type of parameters if any.
- `Gate`: A parametric concrete type that contains the ids of qubits it targets to and the parameters of the operator, if any. It contains the operator as a type parameter.

This simplifies many things in the design of the library, making the library more Julian. It also experiments with a new kind of "attribute" and "behaviour" inheritance, common in OOP, but using just multiple dispatch and parametric types.