### PR TITLE
Fix multi-qubit gate visualization

### DIFF
--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -154,8 +154,8 @@ function draw_multiblock_mid(; background = nothing)
         line(Point(25, 0), Point(15, 0), action = :stroke)
 
         # vertical lines
-        line(Point(-15, -25), Point(-15, 25), action = :stroke)
-        line(Point(15, -25), Point(15, 25), action = :stroke)
+        line(Point(-25, 0), Point(25, 0), action = :stroke)
+        line(Point(0, -25), Point(0, 25), action = :stroke)
     end 50 50
 end
 


### PR DESCRIPTION
### Summary
Previously, the visualization of two-qubit gates operating on disjoint qubit lanes displayed incorrect vertical connections. In this Pull Request, we have addressed this issue and rectified the inaccurate visualization.

### Example
The previous version of the code produced an inaccurate visualization when executing the following script:
```julia
julia> circ = Circuit(4)

julia> push!(circ, Swap(1, 3))

julia> push!(circ, CZ(1,4))

julia> circ
```
The output:
![image](https://github.com/bsc-quantic/Quac.jl/assets/61060572/61b0159c-9f41-4b7d-b962-ca31020ba41f)

With the improvements implemented in this PR, the same script now produces the correct visual output:
![image](https://github.com/bsc-quantic/Quac.jl/assets/61060572/6a3bbac2-c695-4829-9a64-a979050c2582)
