### PR TITLE
Add `Hz` and `FSim` gates

### DIFF
--- a/src/Array.jl
+++ b/src/Array.jl
@@ -56,6 +56,16 @@ Matrix{T}(g::G) where {T,G<:Gate{U3}} = Matrix{T}([
     cos(g.θ / 2) -cis(g.λ)*sin(g.θ / 2)
     cis(g.ϕ)*sin(g.θ / 2) cis(g.ϕ + g.λ)*cos(g.θ / 2)
 ])
+Matrix{T}(g::G) where {T,G<:Gate{Hz}} = Matrix{T}([
+    exp(1im * π * g.θ / 2)*cos(π * g.θ / 2) -1im * exp(-1im * π * (g.θ/2 - g.ϕ))*sin(π * g.θ / 2)
+    -1im * exp(-1im * π * (g.θ/2 + g.ϕ))*sin(π * g.θ / 2) exp(1im * π * g.θ / 2)*cos(π * g.θ / 2)
+])
+Matrix{T}(g::G) where {T,G<:Gate{FSim}} = Matrix{T}([
+    1 0 0 0
+    0 cos(g.θ) -1im*sin(g.ϕ) 0
+    0 -1im*sin(g.ϕ) cos(g.θ) 0
+    0 0 0 1
+])
 
 function Matrix{T}(::Type{Gate{Op}}) where {T,Op<:Control}
     n = length(Op)

--- a/src/Gate.jl
+++ b/src/Gate.jl
@@ -143,6 +143,14 @@ abstract type U3 <: Operator{NamedTuple{(:θ, :ϕ, :λ),Tuple{Float64,Float64,Fl
 Base.length(::Type{U3}) = 1
 
 """
+    Hz(lane, θ, ϕ)
+
+The Hz (PhasedXPow) gate, equivalent to ``Z^ϕ X^θ Z^{-ϕ}``.
+"""
+abstract type Hz <: Operator{NamedTuple{(:θ, :ϕ),Tuple{Float64,Float64}}} end
+Base.length(::Type{Hz}) = 1
+
+"""
     Swap(lane1, lane2)
 
 The SWAP gate.
@@ -157,14 +165,6 @@ The FSim (Fermionic Simulation) gate.
 """
 abstract type FSim <: Operator{NamedTuple{(:θ, :ϕ),Tuple{Float64,Float64}}} end
 Base.length(::Type{FSim}) = 2
-
-"""
-    Hz(lane, θ, ϕ)
-
-The Hz (PhasedXPow) gate, equivalent to Z^ϕ·X^θ·Z^(-ϕ).
-"""
-abstract type Hz <: Operator{NamedTuple{(:θ, :ϕ),Tuple{Float64,Float64}}} end
-Base.length(::Type{Hz}) = 1
 
 """
     Control(lane, op::Gate)

--- a/src/Gate.jl
+++ b/src/Gate.jl
@@ -2,8 +2,8 @@ export Gate, Operator
 export lanes
 export X, Y, Z, H, S, Sd, T, Td
 export isparametric, parameters
-export Rx, Ry, Rz, U1, U2, U3
-export Control, Swap
+export Rx, Ry, Rz, U1, U2, U3, Hz
+export Control, Swap, FSim
 export CX, CY, CZ, CRx, CRy, CRz
 export control, target, operator
 export Pauli, Phase
@@ -151,6 +151,22 @@ abstract type Swap <: StaticOperator end
 Base.length(::Type{Swap}) = 2
 
 """
+    FSim(lane1, lane2, θ, ϕ)
+
+The FSim (Fermionic Simulation) gate.
+"""
+abstract type FSim <: Operator{NamedTuple{(:θ, :ϕ),Tuple{Float64,Float64}}} end
+Base.length(::Type{FSim}) = 2
+
+"""
+    Hz(lane, θ, ϕ)
+
+The Hz (PhasedXPow) gate, equivalent to Z^ϕ·X^θ·Z^(-ϕ).
+"""
+abstract type Hz <: Operator{NamedTuple{(:θ, :ϕ),Tuple{Float64,Float64}}} end
+Base.length(::Type{Hz}) = 1
+
+"""
     Control(lane, op::Gate)
 
 A controlled gate.
@@ -177,7 +193,7 @@ Base.adjoint(::Type{Control{Op}}) where {Op} = Control{adjoint(Op)}
 
 # operator sets
 const Pauli = Union{I,X,Y,Z}
-const Phase = Union{I,Z,S,Sd,T,Td,Rz}
+const Phase = Union{I,Z,S,Sd,T,Td,Rz,Hz,FSim}
 
 """
     Gate{Operator}(lanes...; parameters...)
@@ -197,7 +213,7 @@ struct Gate{Op<:Operator,N,Params}
 end
 
 # constructor aliases
-for Op in [:I, :X, :Y, :Z, :H, :S, :Sd, :T, :Td, :U2, :U3, :Rx, :Ry, :Rz, :Swap]
+for Op in [:I, :X, :Y, :Z, :H, :S, :Sd, :T, :Td, :U2, :U3, :Rx, :Ry, :Rz, :Swap, :Hz, :FSim]
     @eval $Op(lanes...; params...) = Gate{$Op}(lanes...; params...)
 end
 

--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -11,6 +11,8 @@ texname(::Type{Rx}) = L"R_X"
 texname(::Type{Ry}) = L"R_Y"
 texname(::Type{Rz}) = L"R_Z"
 
+texname(::Type{Hz}) = L"H_Z"
+texname(::Type{FSim}) = L"F_S"
 function draw end
 export draw
 
@@ -79,7 +81,7 @@ function draw(::Gate{I,1,NamedTuple{(),Tuple{}}}; background = nothing)
     end 50 50
 end
 
-for Op in [X, Y, Z, H, S, Sd, T, Td, Rx, Ry, Rz]
+for Op in [X, Y, Z, H, S, Sd, T, Td, Rx, Ry, Rz, Hz, FSim]
     @eval draw(::Gate{$Op,1,P}; kwargs...) where {P} = draw_block(texname($Op); kwargs...)
 end
 


### PR DESCRIPTION
This PR adds two important gates, the `Hz` ([PhasedXPow](https://quantumai.google/reference/python/cirq/PhasedXPowGate)) and the `FSim` ([Fermionic Simulation](https://quantumai.google/reference/python/cirq/FSimGate)), which are used widely in `qFlex` circuits.