### PR TITLE
Move away from `Luxor` for visualization

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,19 +4,12 @@ authors = ["Sergio Sánchez Ramírez <sergio.sanchez.ramirez@bsc.es>"]
 version = "0.2.1"
 
 [deps]
+Cobweb = "ec354790-cf28-43e8-bb59-b484409b7bad"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
-LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-Luxor = "ae8d54c2-7ccd-5906-9d76-62fc9837b5bc"
-MathTeXEngine = "0a4f8689-d25c-4efe-a92b-7142dfc1aa53"
-Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SimpleWeightedGraphs = "47aef6b3-ad0c-573a-a1e2-d07658019622"
 
 [compat]
 Combinatorics = "1.0.0"
-LaTeXStrings = "1.3"
-Luxor = "3.5"
-MathTeXEngine = "0.5"
-Requires = "1.0"
 SimpleWeightedGraphs = "1.2"
 julia = "1.8"

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SimpleWeightedGraphs = "47aef6b3-ad0c-573a-a1e2-d07658019622"
 
 [compat]
+Cobweb = "0.5"
 Combinatorics = "1.0.0"
 SimpleWeightedGraphs = "1.2"
 julia = "1.8"

--- a/src/Quac.jl
+++ b/src/Quac.jl
@@ -1,15 +1,9 @@
 module Quac
 
-using Requires: @require
-
 include("Gate.jl")
 include("Array.jl")
 include("Circuit.jl")
 include("Algorithms.jl")
-
-function __init__()
-    @require Luxor = "ae8d54c2-7ccd-5906-9d76-62fc9837b5bc" include("Visualization.jl")
-    @require VSCodeServer = "9f5989ce-84fe-42d4-91ec-6a7a8d53ed0f" using Luxor
-end
+include("Visualization.jl")
 
 end

--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -28,7 +28,7 @@ const DRAWING_STYLE = h.style(
 
     .block {
         stroke: black;
-        fill: white;
+        fill: transparent;
     }
 
     text {

--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -16,7 +16,7 @@ texname(::Type{FSim}) = """F<tspan font-size="60%" baseline-shift="sub">S</tspan
 function draw end
 export draw
 
-const DRAWING_STYLE = h.style(
+const DEFAULT_STYLE = h.style(
     """
     .wire {
         stroke: black;
@@ -66,7 +66,7 @@ function draw(circuit::Circuit; kwargs...)
 
     if isempty(circuit)
         svg = __svg_vcat_blocks([draw(Gate{I}(lane); kwargs...) for lane in 1:n]...)
-        push!(svg, DRAWING_STYLE)
+        push!(svg, DEFAULT_STYLE)
         return svg
     end
 
@@ -100,7 +100,7 @@ function draw(circuit::Circuit; kwargs...)
         mapreduce(x -> draw(x; kwargs...), __svg_vcat_blocks, moment)
     end
 
-    push!(svg, DRAWING_STYLE)
+    push!(svg, DEFAULT_STYLE)
 
     return svg
 end


### PR DESCRIPTION
This PR closes #11 (partially),#21 and #30 by moving away from `Luxor` (and the extra dependencies `MathTeXEngine` and `LaTeXStrings`) and using `Cobweb` for directly writing SVG code.

I've found out that `Luxor` is quite a heavy package. This PR substantially decreases package load and precompilation times to almost none, and eases dependency complexity.

`Cobweb` doesn't rely on `libxml2` for writing XML-like code (e.g. `EzXML`) so the package is veeery light.