### PR TITLE
Implement generic `SU{N}` operator

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.2.4"
 Cobweb = "ec354790-cf28-43e8-bb59-b484409b7bad"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SimpleWeightedGraphs = "47aef6b3-ad0c-573a-a1e2-d07658019622"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,6 @@ version = "0.2.4"
 Cobweb = "ec354790-cf28-43e8-bb59-b484409b7bad"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SimpleWeightedGraphs = "47aef6b3-ad0c-573a-a1e2-d07658019622"
 
 [compat]

--- a/docs/src/api/gates.md
+++ b/docs/src/api/gates.md
@@ -102,11 +102,9 @@ Control
 Swap
 ```
 
-## A General Unitary SU{N} gate
-The `SU{N}` gate is a general unitary gate that can be used to represent any unitary matrix that acts on
-`log2(N)` qubits. A new random `SU{N}` can be created with `rand(SU{N}, lanes...)`, where `N` is the dimension of the unitary matrix and `lanes` are the qubit lanes on which the gate acts.
+## Special Unitary gate
 
-!!! tip "Experimental interface"
+!!! warn "Experimental interface"
     This interface is experimental and may change in the future.
 
 ```@docs

--- a/docs/src/api/gates.md
+++ b/docs/src/api/gates.md
@@ -101,3 +101,14 @@ Control
 ```@docs
 Swap
 ```
+
+## A General Unitary SU{N} gate
+The `SU{N}` gate is a general unitary gate that can be used to represent any unitary matrix that acts on
+`log2(N)` qubits. A new random `SU{N}` can be created with `rand(SU{N}, lanes...)`, where `N` is the dimension of the unitary matrix and `lanes` are the qubit lanes on which the gate acts.
+
+!!! tip "Experimental interface"
+    This interface is experimental and may change in the future.
+
+```@docs
+Quac.SU{N}
+```

--- a/src/Array.jl
+++ b/src/Array.jl
@@ -1,6 +1,6 @@
 import Base: Matrix, Array
 import LinearAlgebra: Diagonal, diag, eigvals, eigvecs, eigen
-using LinearAlgebra: Eigen, LinearAlgebra
+using LinearAlgebra: Eigen, LinearAlgebra, qr
 
 # preferred representation
 function arraytype end
@@ -13,7 +13,7 @@ for G in [I, Z, S, Sd, T, Td, Rz]
     @eval arraytype(::Type{<:Gate{$G}}) = Diagonal
 end
 
-for G in [X, Y, H, Rx, Ry]
+for G in [X, Y, H, Rx, Ry, SU]
     @eval arraytype(::Type{<:Gate{$G}}) = Matrix
 end
 
@@ -22,7 +22,7 @@ end
 Matrix(x::Gate) = Matrix{ComplexF32}(x)
 Matrix(::Type{T}) where {T<:Gate} = Matrix{ComplexF32}(T)
 
-for Op in [I, X, Y, Z, H, S, Sd, T, Td, Swap]
+for Op in [I, X, Y, Z, H, S, Sd, T, Td, Swap, SU]
     @eval Matrix{T}(::G) where {T,G<:Gate{$Op}} = Matrix{T}(G)
 end
 
@@ -117,6 +117,18 @@ function Matrix{T}(g::Gate{<:Control}) where {T}
     M[(2^n-2^t+1):end, (2^n-2^t+1):end] = Matrix{T}(Gate{targettype(operator(g))}(target(g)...; parameters(g)...))
 
     return M
+end
+
+function Matrix{T}(g::Gate{<:SU}) where {T}
+    N = 2^length(g)
+
+    # Create a NxN random complex matrix
+    z = rand(T, N, N)
+
+    # QR decomposition to make it unitary
+    Q, _ = qr(z)
+
+    return Matrix{T}(Q)
 end
 
 Array(x::Gate) = Array{ComplexF32}(x)

--- a/src/Array.jl
+++ b/src/Array.jl
@@ -123,13 +123,13 @@ function Base.rand(::Type{SU{N}}, lanes::NTuple{M, Int}; eltype::Type = ComplexF
     # keep unitary matrix Q from QR decomposition
     q, _ = qr(rand(eltype, N, N))
 
-    SU{N}(lanes...; values = Matrix(q))
+    SU{N}(lanes...; array = Matrix(q))
 end
 
 Base.rand(::Type{Gate{SU{N}}}, lanes::Integer...; kwargs...) where {N} = rand(SU{N}, lanes; kwargs...)
 
 function Matrix{T}(g::Gate{<:SU{N}}) where {T, N}
-    return g.values |> Matrix{T}
+    return g.array |> Matrix{T}
 end
 
 Array(x::Gate) = Array{ComplexF32}(x)

--- a/src/Array.jl
+++ b/src/Array.jl
@@ -134,8 +134,8 @@ function Base.rand(ElType::Type, ::Type{SU{N}}, lanes::NTuple{M, Int}; seed::Uni
     SU{N}(lanes...; values = Matrix{ElType}(q))
 end
 
-Base.rand(::Type{SU{N}}, lanes::NTuple{M, Int}; seed::Union{Int, Nothing}=nothing) where {N, M} = rand(ComplexF32, SU{N}, lanes; seed = seed)
-Base.rand(::Type{Gate{SU{N}}}, lanes::Integer...; seed::Union{Int, Nothing}=nothing) where {N} = rand(ComplexF32, SU{N}, lanes; seed = seed)
+Base.rand(::Type{SU{N}}, lanes::NTuple{M, Int}; seed::Union{Int, Nothing}=nothing) where {N, M} = rand(ComplexF64, SU{N}, lanes; seed = seed)
+Base.rand(::Type{Gate{SU{N}}}, lanes::Integer...; seed::Union{Int, Nothing}=nothing) where {N} = rand(ComplexF64, SU{N}, lanes; seed = seed)
 
 function Matrix{T}(g::Gate{<:SU{N}}) where {T, N}
     return g.values |> Matrix{T}

--- a/src/Array.jl
+++ b/src/Array.jl
@@ -119,9 +119,7 @@ function Matrix{T}(g::Gate{<:Control}) where {T}
     return M
 end
 
-function Matrix{T}(g::Gate{<:SU}) where {T}
-    N = 2^length(g)
-
+function Matrix{T}(g::Gate{<:SU{N}}) where {T, N}
     # Create a NxN random complex matrix
     z = rand(T, N, N)
 

--- a/src/Array.jl
+++ b/src/Array.jl
@@ -120,7 +120,6 @@ function Matrix{T}(g::Gate{<:Control}) where {T}
 end
 
 function Base.rand(::Type{SU{N}}, lanes::NTuple{M, Int}; eltype::Type = ComplexF64) where {N, M}
-
     # keep unitary matrix Q from QR decomposition
     q, _ = qr(rand(eltype, N, N))
 

--- a/src/Array.jl
+++ b/src/Array.jl
@@ -1,7 +1,6 @@
 import Base: Matrix, Array
 import LinearAlgebra: Diagonal, diag, eigvals, eigvecs, eigen
 using LinearAlgebra: Eigen, LinearAlgebra, qr
-using Random
 
 # preferred representation
 function arraytype end
@@ -120,22 +119,15 @@ function Matrix{T}(g::Gate{<:Control}) where {T}
     return M
 end
 
-function Base.rand(ElType::Type, ::Type{SU{N}}, lanes::NTuple{M, Int}; seed::Union{Int, Nothing}=nothing) where {N, M}
-    if seed !== nothing
-        Random.seed!(seed)
-    end
+function Base.rand(::Type{SU{N}}, lanes::NTuple{M, Int}; eltype::Type = ComplexF64) where {N, M}
 
-    # Generate random numbers here
-    random_values = rand(ElType, N, N)
+    # keep unitary matrix Q from QR decomposition
+    q, _ = qr(rand(eltype, N, N))
 
-    # Use QR to make it unitary
-    q, _ = qr(random_values)
-
-    SU{N}(lanes...; values = Matrix{ElType}(q))
+    SU{N}(lanes...; values = Matrix(q))
 end
 
-Base.rand(::Type{SU{N}}, lanes::NTuple{M, Int}; seed::Union{Int, Nothing}=nothing) where {N, M} = rand(ComplexF64, SU{N}, lanes; seed = seed)
-Base.rand(::Type{Gate{SU{N}}}, lanes::Integer...; seed::Union{Int, Nothing}=nothing) where {N} = rand(ComplexF64, SU{N}, lanes; seed = seed)
+Base.rand(::Type{Gate{SU{N}}}, lanes...; kwargs...) where {N} = rand(SU{N}, lanes; kwargs...)
 
 function Matrix{T}(g::Gate{<:SU{N}}) where {T, N}
     return g.values |> Matrix{T}

--- a/src/Array.jl
+++ b/src/Array.jl
@@ -126,7 +126,7 @@ function Base.rand(::Type{SU{N}}, lanes::NTuple{M, Int}; eltype::Type = ComplexF
     SU{N}(lanes...; values = Matrix(q))
 end
 
-Base.rand(::Type{Gate{SU{N}}}, lanes...; kwargs...) where {N} = rand(SU{N}, lanes; kwargs...)
+Base.rand(::Type{Gate{SU{N}}}, lanes::Integer...; kwargs...) where {N} = rand(SU{N}, lanes; kwargs...)
 
 function Matrix{T}(g::Gate{<:SU{N}}) where {T, N}
     return g.values |> Matrix{T}

--- a/src/Gate.jl
+++ b/src/Gate.jl
@@ -263,7 +263,7 @@ function SU{N}(lanes...; array::Matrix) where {N}
     ispow2(N) || throw(DomainError(N, "N must be a power of 2"))
     2^length(lanes) == N || throw(ArgumentError("SU{$N} requires $(log2(N) |> Int) lanes"))
     size(array) == (N,N) || throw(ArgumentError("`array` must be a (N,N)-size matrix"))
-    isapprox(array * adjoint(array), Matrix{Complex64}(LinearAlgebra.I, N, N)) || throw(ArgumentError("`array` is not unitary"))
+    isapprox(array * adjoint(array), Matrix{ComplexF64}(LinearAlgebra.I, N, N)) || throw(ArgumentError("`array` is not unitary"))
 
     Gate{SU{N}}(lanes...; array)
 end

--- a/src/Gate.jl
+++ b/src/Gate.jl
@@ -211,7 +211,7 @@ parameters(::Type{Control{Op}}) where {Op} = parameters(Op)
 
 A multi-qubit random unitary operator that acts on `log2(N)` qubits.
 """
-abstract type SU{N} <: Operator{NamedTuple{(:values, :N), Tuple{Matrix, Int}}} where {T, N<:Int} end
+abstract type SU{N} <: Operator{NamedTuple{(:values,), Tuple{Matrix}}} end
 Base.length(::Type{SU{N}}) where {N} =
     (N & (N - 1) == 0 && N > 0) ? log2(N) |> Int : throw(DomainError(N, "N must be a power of 2"))
 

--- a/src/Gate.jl
+++ b/src/Gate.jl
@@ -211,7 +211,7 @@ parameters(::Type{Control{Op}}) where {Op} = parameters(Op)
 
 A multi-qubit random unitary operator that acts on `log2(N)` qubits.
 """
-abstract type SU{N} <: Operator{NamedTuple{(:values,), Tuple{Matrix}}} end
+abstract type SU{N} <: Operator{NamedTuple{(:array,), Tuple{Matrix}}} end
 Base.length(::Type{SU{N}}) where {N} =
     (N & (N - 1) == 0 && N > 0) ? log2(N) |> Int : throw(DomainError(N, "N must be a power of 2"))
 
@@ -259,14 +259,14 @@ end
 
 # separate constructor for SU
 function SU{N}(lanes...; params...) where {N}
-    # raise error if values is not in params or is not a Matrix
-    if !haskey(params, :values) || !isa(params[:values], Matrix) || size(params[:values]) != (N,N) || (N & (N - 1) != 0) || N <= 0
-        throw(ArgumentError("SU{N} requires a `values` N x N Matrix parameter, where N is a power of 2"))
+    # raise error if array is not in params or is not a Matrix
+    if !haskey(params, :array) || !isa(params[:array], Matrix) || size(params[:array]) != (N,N) || (N & (N - 1) != 0) || N <= 0
+        throw(ArgumentError("SU{N} requires a `array` N x N Matrix parameter, where N is a power of 2"))
     end
 
     # raise error if Matrix is not unitary
-    if !isapprox(params[:values] * adjoint(params[:values]), Matrix{ComplexF32}(LinearAlgebra.I, N, N), atol=1e-6)
-        throw(ArgumentError("SU{N} requires a unitary Matrix `values` parameter"))
+    if !isapprox(params[:array] * adjoint(params[:array]), Matrix{ComplexF32}(LinearAlgebra.I, N, N), atol=1e-6)
+        throw(ArgumentError("SU{N} requires a unitary Matrix `array` parameter"))
     end
 
     # raise error if lanes is not log2(N)
@@ -274,7 +274,7 @@ function SU{N}(lanes...; params...) where {N}
         throw(ArgumentError("SU{N} requires `log2(N)` lanes"))
     end
 
-    Gate{SU{N}}(lanes...; params..., N = log2(N) |> Int)
+    Gate{SU{N}}(lanes...; params...)
 end
 
 Base.sqrt(g::Gate{X}) = Rx(lanes(g)..., θ = π / 2)
@@ -312,7 +312,7 @@ Base.getproperty(g::Gate{Op}, i::Symbol) where {Op} = i ∈ propertynames(g) ? p
 Base.adjoint(::Type{<:Gate{Op}}) where {Op} = Gate{adjoint(Op)}
 Base.adjoint(::Type{Gate{Op,N,P}}) where {Op,N,P} = Gate{adjoint(Op),N,P}
 Base.adjoint(g::Gate{Op}) where {Op} = Gate{Op'}(lanes(g)...; [key => -val for (key, val) in pairs(parameters(g))]...)
-Base.adjoint(g::Gate{SU{N}}) where {N} = Gate{SU{N}}(lanes(g)...; values = adjoint(g.values), N = log2(N) |> Int)
+Base.adjoint(g::Gate{SU{N}}) where {N} = Gate{SU{N}}(lanes(g)...; array = adjoint(g.array))
 
 # NOTE useful type piracy
 Base.rand(::Type{NamedTuple{N,T}}) where {N,T} = NamedTuple{N}(rand(type) for type in T.parameters)

--- a/src/Gate.jl
+++ b/src/Gate.jl
@@ -209,7 +209,9 @@ parameters(::Type{Control{Op}}) where {Op} = parameters(Op)
 """
     SU(N)(lane_1, lane_2, ..., lane_log2(N))
 
-A multi-qubit random unitary operator that acts on `log2(N)` qubits.
+The `SU{N}` multi-qubit general unitary gate that can be used to represent any unitary matrix that acts on
+`log2(N)` qubits. A new random `SU{N}` can be created with `rand(SU{N}, lanes...)`, where `N` is the dimension
+ of the unitary matrix and `lanes` are the qubit lanes on which the gate acts.
 """
 abstract type SU{N} <: Operator{NamedTuple{(:array,), Tuple{Matrix}}} end
 Base.length(::Type{SU{N}}) where {N} =
@@ -261,7 +263,7 @@ function SU{N}(lanes...; array::Matrix) where {N}
     ispow2(N) || throw(DomainError(N, "N must be a power of 2"))
     2^length(lanes) == N || throw(ArgumentError("SU{$N} requires $(log2(N) |> Int) lanes"))
     size(array) == (N,N) || throw(ArgumentError("`array` must be a (N,N)-size matrix"))
-    isapprox(array * adjoint(array), LinearAlgebra.I(N))) || throw(ArgumentError("`array` is not unitary"))
+    isapprox(array * adjoint(array), Matrix{Complex64}(LinearAlgebra.I, N, N)) || throw(ArgumentError("`array` is not unitary"))
 
     Gate{SU{N}}(lanes...; array)
 end

--- a/src/Gate.jl
+++ b/src/Gate.jl
@@ -258,7 +258,7 @@ for Op in [:I, :X, :Y, :Z, :H, :S, :Sd, :T, :Td, :U2, :U3, :Rx, :Ry, :Rz, :Rxx, 
 end
 
 # separate constructor for SU
-@eval function SU{N}(lanes...; params...) where {N}
+function SU{N}(lanes...; params...) where {N}
     # raise error if values is not in params or is not a Matrix
     if !haskey(params, :values) || !isa(params[:values], Matrix) || size(params[:values]) != (N,N) || (N & (N - 1) != 0) || N <= 0
         throw(ArgumentError("SU{N} requires a `values` N x N Matrix parameter, where N is a power of 2"))

--- a/test/Array_test.jl
+++ b/test/Array_test.jl
@@ -25,6 +25,12 @@
             @test size(Matrix(Gate{Op})) == (2^length(Op), 2^length(Op))
         end
 
+        # Special case for SU{N}
+        for N in [2, 4, 8]
+            @test Matrix(rand(Gate{SU{N}}, 1:Int(log2(N))...)) isa Matrix{ComplexF32}
+            @test size(Matrix(rand(Gate{SU{N}}, 1:Int(log2(N))...))) == (N, N)
+        end
+
         for Op in [
             I,
             X,

--- a/test/Gate_test.jl
+++ b/test/Gate_test.jl
@@ -411,21 +411,21 @@
 
     @testset "random unitary" begin
         # test_throws on a non-unitary matrix
-        @test_throws ArgumentError SU{4}(1, 2; array = rand(ComplexF32, 4, 4), N = 2)
+        @test_throws ArgumentError SU{4}(1, 2; array = rand(ComplexF32, 4, 4))
 
         # test_throws on a non-square matrix
-        @test_throws ArgumentError SU{4}(1, 2; array = rand(ComplexF32, 4, 2), N = 2)
+        @test_throws ArgumentError SU{4}(1, 2; array = rand(ComplexF32, 4, 2))
 
         # test_throws on a matrix without size (N, N)
-        @test_throws ArgumentError SU{4}(1, 2; array = rand(ComplexF32, 2, 2), N = 2)
+        @test_throws ArgumentError SU{4}(1, 2; array = rand(ComplexF32, 2, 2))
 
         # test_throws SU{N} with N not a power of 2
-        @test_throws ArgumentError SU{3}(1, 2; array = rand(ComplexF32, 3, 3), N = 2)
+        @test_throws ArgumentError SU{3}(1, 2; array = rand(ComplexF32, 3, 3))
 
         # test_throws when there are not log2(N) lanes
         rand_matrix = rand(ComplexF32, 4, 4)
         q, _ = qr(rand_matrix)
-        @test_throws ArgumentError SU{4}(1, 2, 3; array = Matrix{ComplexF32}(q), N = 2)
+        @test_throws ArgumentError SU{4}(1, 2, 3; array = Matrix{ComplexF32}(q))
     end
 
     @testset "target" begin

--- a/test/Gate_test.jl
+++ b/test/Gate_test.jl
@@ -44,10 +44,10 @@
         # Special case for SU{N}
        for N in [2, 4, 8]
             _lanes = range(1, length = log2(N) |> Int)
-            random_values = rand(ComplexF32, N, N)
-            q, _ = qr(random_values)
-            _values = Matrix{ComplexF32}(q)
-            @test Gate{SU{N}}(_lanes...; values = _values, N = N) !== nothing
+            rand_matrix = rand(ComplexF32, N, N)
+            q, _ = qr(rand_matrix)
+            array = Matrix{ComplexF32}(q)
+            @test Gate{SU{N}}(_lanes...; array = array) !== nothing
         end
     end
 
@@ -90,10 +90,10 @@
         # Special case for SU{N}
         for N in [2, 4, 8]
             _lanes = range(1, length = log2(N) |> Int)
-            random_values = rand(ComplexF32, N, N)
-            q, _ = qr(random_values)
-            _values = Matrix{ComplexF64}(q)
-            @test SU{N}(_lanes...; values = _values) isa Gate{SU{N},log2(N) |> Int, NamedTuple{(:values, :N),Tuple{Matrix,Int}}}
+            rand_matrix = rand(ComplexF32, N, N)
+            q, _ = qr(rand_matrix)
+            array = Matrix{ComplexF64}(q)
+            @test SU{N}(_lanes...; array = array) isa Gate{SU{N},log2(N) |> Int, NamedTuple{(:array,),Tuple{Matrix}}}
         end
     end
 
@@ -134,10 +134,10 @@
         # Special case for SU{N}
         for N in [2, 4, 8]
             _lanes = 1:length(SU{N}) |> collect
-            random_values = rand(ComplexF32, N, N)
-            q, _ = qr(random_values)
-            _values = Matrix{ComplexF32}(q)
-            @test lanes(Gate{SU{N}}(_lanes...; values = _values, N = log2(N))) === tuple(1:length(SU{N})...)
+            rand_matrix = rand(ComplexF32, N, N)
+            q, _ = qr(rand_matrix)
+            array = Matrix{ComplexF32}(q)
+            @test lanes(Gate{SU{N}}(_lanes...; array = array)) === tuple(1:length(SU{N})...)
         end
     end
 
@@ -179,10 +179,10 @@
         # Special case for SU{N}
         for N in [2, 4, 8]
             _lanes = 1:length(SU{N}) |> collect
-            random_values = rand(ComplexF32, N, N)
-            q, _ = qr(random_values)
-            _values = Matrix{ComplexF32}(q)
-            @test operator(Gate{SU{N}}(_lanes...; values = _values, N = log2(N))) === SU{N}
+            rand_matrix = rand(ComplexF32, N, N)
+            q, _ = qr(rand_matrix)
+            array = Matrix{ComplexF32}(q)
+            @test operator(Gate{SU{N}}(_lanes...; array = array)) === SU{N}
         end
     end
 
@@ -228,11 +228,10 @@
             @test parameters(Gate{SU{N}}) === parameters(SU{N})
 
             _lanes = 1:length(SU{N}) |> collect
-            random_values = rand(ComplexF32, N, N)
-            q, _ = qr(random_values)
-            _values = Matrix{ComplexF32}(q)
-            @test parameters(Gate{SU{N}}(_lanes...; values = _values, N = log2(N) |> Int)).values === _values
-            @test parameters(Gate{SU{N}}(_lanes...; values = _values, N = log2(N) |> Int)).N === log2(N) |> Int
+            rand_matrix = rand(ComplexF32, N, N)
+            q, _ = qr(rand_matrix)
+            array = Matrix{ComplexF32}(q)
+            @test parameters(Gate{SU{N}}(_lanes...; array = array)).array === array
         end
     end
 
@@ -287,12 +286,10 @@
             @test_throws MethodError adjoint(Gate{SU{N}})
 
             _lanes = 1:length(SU{N}) |> collect
-            random_values = rand(ComplexF32, N, N)
-            q, _ = qr(random_values)
-            _values = Matrix{ComplexF32}(q)
+            rand_matrix = rand(ComplexF64, N, N)
+            q, _ = qr(rand_matrix)
 
-            @test adjoint(SU{N}(_lanes...; values = _values, N = log2(N) |> Int)).values == adjoint(_values)
-            @test adjoint(SU{N}(_lanes...; values = _values, N = log2(N) |> Int)).N === log2(N) |> Int
+            @test adjoint(SU{N}(_lanes...; array = Matrix{ComplexF64}(q))).array == adjoint(Matrix{ComplexF64}(q))
         end
     end
 
@@ -414,21 +411,21 @@
 
     @testset "random unitary" begin
         # test_throws on a non-unitary matrix
-        @test_throws ArgumentError SU{4}(1, 2; values = rand(ComplexF32, 4, 4), N = 2)
+        @test_throws ArgumentError SU{4}(1, 2; array = rand(ComplexF32, 4, 4), N = 2)
 
         # test_throws on a non-square matrix
-        @test_throws ArgumentError SU{4}(1, 2; values = rand(ComplexF32, 4, 2), N = 2)
+        @test_throws ArgumentError SU{4}(1, 2; array = rand(ComplexF32, 4, 2), N = 2)
 
         # test_throws on a matrix without size (N, N)
-        @test_throws ArgumentError SU{4}(1, 2; values = rand(ComplexF32, 2, 2), N = 2)
+        @test_throws ArgumentError SU{4}(1, 2; array = rand(ComplexF32, 2, 2), N = 2)
 
         # test_throws SU{N} with N not a power of 2
-        @test_throws ArgumentError SU{3}(1, 2; values = rand(ComplexF32, 3, 3), N = 2)
+        @test_throws ArgumentError SU{3}(1, 2; array = rand(ComplexF32, 3, 3), N = 2)
 
         # test_throws when there are not log2(N) lanes
-        rand_values = rand(ComplexF32, 4, 4)
-        q, _ = qr(rand_values)
-        @test_throws ArgumentError SU{4}(1, 2, 3; values = Matrix{ComplexF32}(q), N = 2)
+        rand_matrix = rand(ComplexF32, 4, 4)
+        q, _ = qr(rand_matrix)
+        @test_throws ArgumentError SU{4}(1, 2, 3; array = Matrix{ComplexF32}(q), N = 2)
     end
 
     @testset "target" begin

--- a/test/Gate_test.jl
+++ b/test/Gate_test.jl
@@ -420,7 +420,7 @@
         @test_throws ArgumentError SU{4}(1, 2; array = rand(ComplexF32, 2, 2))
 
         # test_throws SU{N} with N not a power of 2
-        @test_throws ArgumentError SU{3}(1, 2; array = rand(ComplexF32, 3, 3))
+        @test_throws DomainError SU{3}(1, 2; array = rand(ComplexF32, 3, 3))
 
         # test_throws when there are not log2(N) lanes
         rand_matrix = rand(ComplexF32, 4, 4)

--- a/test/Gate_test.jl
+++ b/test/Gate_test.jl
@@ -90,7 +90,7 @@
         # Special case for SU{N}
         for N in [2, 4, 8]
             _lanes = range(1, length = log2(N) |> Int)
-            rand_matrix = rand(ComplexF32, N, N)
+            rand_matrix = rand(ComplexF64, N, N)
             q, _ = qr(rand_matrix)
             array = Matrix{ComplexF64}(q)
             @test SU{N}(_lanes...; array = array) isa Gate{SU{N},log2(N) |> Int, NamedTuple{(:array,),Tuple{Matrix}}}

--- a/test/Gate_test.jl
+++ b/test/Gate_test.jl
@@ -92,7 +92,7 @@
             _lanes = range(1, length = log2(N) |> Int)
             random_values = rand(ComplexF32, N, N)
             q, _ = qr(random_values)
-            _values = Matrix{ComplexF32}(q)
+            _values = Matrix{ComplexF64}(q)
             @test SU{N}(_lanes...; values = _values) isa Gate{SU{N},log2(N) |> Int, NamedTuple{(:values, :N),Tuple{Matrix,Int}}}
         end
     end


### PR DESCRIPTION
### Summary
This PR introduces a generic `SU{N}` operator to represent multi-qubit random unitary gates as part of the preparations for implementing the Quantum Volume circuit (#36).

The function `rand(SU{N}, lanes...)`  generates a random unitary on $\log_2(N)$ qubits, but the `Gate` can also be created with `Gate{SU{N}}(lanes..., values=values)`, where `values` should be an unitary $N \times N$ `Matrix`.

#### TO DO:
- [x] Right now an `SU(N)` operator will have different numbers each time we call `Matrix(SU(4)(1, 2))`, this should be fixed.
- [x] Add tests.

### Example usage
Here is an example of how this operator works:
```julia
julia> using Quac

julia> gate = rand(SU{4}, 1, 2)
SU{4}(1,2,values=ComplexF32[-0.27525437f0 - 0.29308861f0im -0.4208821f0 - 0.18467489f0im 0.14470652f0 + 0.23815393f0im 0.3791096f0 + 0.6369507f0im; -0.26461214f0 - 0.5085059f0im -0.22114944f0 + 0.3909977f0im -0.47308114f0 + 0.35186514f0im -0.15420634f0 - 0.31340322f0im; -0.4832718f0 - 0.28003073f0im 0.2184682f0 + 0.14621824f0im -0.059832215f0 - 0.7371828f0im -0.14579253f0 + 0.22505373f0im; -0.42705068f0 - 0.12407699f0im -0.06541614f0 - 0.7166448f0im 0.16627984f0 + 0.0077809766f0im -0.048846245f0 - 0.50425994f0im],N=2)

julia> Matrix(gate)
4×4 Matrix{ComplexF32}:
 -0.275254-0.293089im   -0.420882-0.184675im    0.144707+0.238154im       0.37911+0.636951im
 -0.264612-0.508506im   -0.221149+0.390998im   -0.473081+0.351865im     -0.154206-0.313403im
 -0.483272-0.280031im    0.218468+0.146218im  -0.0598322-0.737183im     -0.145793+0.225054im
 -0.427051-0.124077im  -0.0654161-0.716645im     0.16628+0.00778098im  -0.0488462-0.50426im

julia> Matrix(gate) * Matrix(adjoint(gate))
4×4 Matrix{ComplexF32}:
         1.0+0.0im         -2.23517f-8+5.21541f-8im  -1.49012f-8+3.0268f-8im   -4.47035f-8+7.45058f-8im
 -2.23517f-8-5.21541f-8im          1.0+0.0im          -1.3411f-7+8.9407f-8im    2.23517f-8-5.96046f-8im
 -1.49012f-8-3.0268f-8im    -1.3411f-7-8.9407f-8im           1.0+0.0im         -1.49012f-8+2.42144f-8im
 -4.47035f-8-7.45058f-8im   2.23517f-8+5.96046f-8im  -1.49012f-8-2.42144f-8im          1.0+0.0im

julia> gate = SU{4}(1, 2; values=rand(4, 4)) # It throws an error when `values` is not a unitary Matrix
ERROR: ArgumentError: SU{N} requires a unitary Matrix `values` parameter
Stacktrace: ...
```