### PR TITLE
Implement `QuantumVolume` Circuit

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.2.4"
 Cobweb = "ec354790-cf28-43e8-bb59-b484409b7bad"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SimpleWeightedGraphs = "47aef6b3-ad0c-573a-a1e2-d07658019622"
 
 [compat]

--- a/docs/src/api/algorithms.md
+++ b/docs/src/api/algorithms.md
@@ -3,3 +3,7 @@
 ```@docs
 Quac.Algorithms.QFT
 ```
+
+```@docs
+Quac.Algorithms.QuantumVolume
+```

--- a/docs/src/api/algorithms.md
+++ b/docs/src/api/algorithms.md
@@ -2,8 +2,5 @@
 
 ```@docs
 Quac.Algorithms.QFT
-```
-
-```@docs
 Quac.Algorithms.QuantumVolume
 ```

--- a/src/Algorithms.jl
+++ b/src/Algorithms.jl
@@ -36,7 +36,7 @@ Generate a Quantum Volume circuit of `n` qubits and `depth` layers. See [1] for 
 [1] Cross, Andrew W., et al. "Validating quantum computers using randomized model circuits." Physical Review A 100.3 (2019): 032328.
 
 """
-function QuantumVolume(n::Int, depth::Int)
+function QuantumVolume(n, depth)
     circuit = Circuit(n)
 
     for _ in 1:depth

--- a/src/Algorithms.jl
+++ b/src/Algorithms.jl
@@ -1,8 +1,10 @@
 module Algorithms
 
 using Quac
+using Random: randperm
 
 export QFT
+export QuantumVolume
 
 """
     QFT(n)
@@ -21,6 +23,35 @@ function QFT(n::Int)
     end
 
     circuit
+end
+
+
+"""
+    QuantumVolume(n, depth)
+
+Generate a Quantum Volume circuit of `n` qubits and `depth` layers. See [1] for more details.
+
+# References
+
+[1] Cross, Andrew W., et al. "Validating quantum computers using randomized model circuits." Physical Review A 100.3 (2019): 032328.
+
+"""
+function QuantumVolume(n::Int, depth::Int)
+    circuit = Circuit(n)
+
+    for _ in 1:depth
+        # Generate a random permutation for this layer
+        permutation = randperm(n)
+
+        for i in 1:2:n-1
+            q1 = permutation[i]
+            q2 = permutation[i + 1]
+
+            push!(circuit, rand(SU{4}, q1, q2))
+        end
+    end
+
+    return circuit
 end
 
 end

--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -17,6 +17,8 @@ texname(::Type{Hz}) = """H<tspan class="subscript">Z</tspan>"""
 
 texname(::Type{FSim}) = """F<tspan class="subscript">S</tspan>"""
 
+texname(::Type{SU{N}}) where {N} = """SU<tspan class="subscript">$(N)</tspan>"""
+
 const DEFAULT_STYLE = h.style(
     """
     .wire {
@@ -118,15 +120,15 @@ end
 
 svg(gate::Gate{Op,1,P}) where {Op,P} = __svg_block(; top = false, bottom = false)
 
-function svg(gate::Gate{Op,N,P}) where {Op,N,P}
+function svg(gate::Gate{Op, N, P}) where {Op, N, P}
     a, b = extrema(lanes(gate))
     r = a:b
 
     blocks = map(lane -> begin
         if lane == a
-            __svg_block(; top = true, bottom = false)
+            __svg_block(texname(Op); top = true, bottom = false)
         elseif lane == b
-            __svg_block(; top = false, bottom = true)
+            __svg_block(texname(Op); top = false, bottom = true)
         elseif lane ∈ setdiff(lanes(gate), [a, b])
             __svg_block(; top = false, bottom = false)
         else

--- a/test/Algorithms_test.jl
+++ b/test/Algorithms_test.jl
@@ -6,7 +6,7 @@
         @test length(circuit.lanes) == 3
     end
 
-    @testset "Quac.Algorithms.QuantumVolume" begin
+    @testset "Quantum Volume" begin
         n_qubits = 4
         depth = 2
 

--- a/test/Algorithms_test.jl
+++ b/test/Algorithms_test.jl
@@ -1,0 +1,18 @@
+@testset "Algorithms" begin
+
+    @testset "Quac.Algorithms.QFT" begin
+        circuit = Quac.Algorithms.QFT(3)
+
+        @test length(circuit.lanes) == 3
+    end
+
+    @testset "Quac.Algorithms.QuantumVolume" begin
+        n_qubits = 4
+        depth = 2
+
+        circuit = Quac.Algorithms.QuantumVolume(n_qubits, depth)
+
+        @test length(circuit.lanes) == n_qubits
+        @test length(circuit) == (n_qubits - n_qubits % 2) * depth
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ using Quac
     include("Gate_test.jl")
     include("Array_test.jl")
     include("Circuit_test.jl")
+    include("Algorithms_test.jl")
 end
 
 using Aqua


### PR DESCRIPTION
### Summary
This PR resolves #36 by introducing the `QuantumVolume` function, which generates a Quantum Volume circuit with a given number of qubits and depth. The Quantum Volume metric is a procedure proposed by [IBM](https://arxiv.org/abs/1811.12926) to evaluate quantum processors' performance and error rates. To implement this circuit, we used the newly introduced `SU{N}` gate (#37).

In this PR we also have added tests for the `Algorithms` module, and we have introduced a small fix in the visualization of multi-qubit gates so now these show the `texname` label on their visualization.

### Example
Here we show an example of this new `Circuit`:
```julia
julia> using Quac

julia> circ = Quac.Algorithms.QuantumVolume(5, 3)
```
![image](https://github.com/bsc-quantic/Quac.jl/assets/61060572/1f0688cc-00c8-4a66-bfba-e6e3929bc396)

