### PR TITLE
Small fixes for `SU{N}` type

### DIFF
--- a/src/Array.jl
+++ b/src/Array.jl
@@ -132,8 +132,6 @@ function Matrix{T}(g::Gate{<:SU{N}}) where {T, N}
     return g.array |> Matrix{T}
 end
 
-Array{T}(g::Gate{SU{N}}) where {T,N} = Array{T,2 * length(g)}(reshape(Matrix{T}(g), fill(2, 2 * Int(log2(N)))...))
-
 Array(x::Gate) = Array{ComplexF32}(x)
 Array(::Type{T}) where {T<:Gate} = Array{ComplexF32}(T)
 
@@ -175,6 +173,8 @@ Array{T,4}(g::G) where {T,G<:Gate{Rzz}} = Array{T,4}(
 Array{T}(::Type{Gate{C}}) where {T,C<:Control} =
     Array{T,2 * length(C)}(reshape(Matrix{T}(Gate{C}), fill(2, 2 * length(C))...))
 Array{T}(g::Gate{C}) where {T,C<:Control} = Array{T,2 * length(C)}(reshape(Matrix{T}(g), fill(2, 2 * length(C))...))
+
+Array{T}(g::Gate{SU{N}}) where {T,N} = Array{T,2 * length(g)}(reshape(Matrix{T}(g), fill(2, 2 * Int(log2(N)))...))
 
 # diagonal matrices
 # NOTE efficient multiplication due to no memory swap needed: plain element-wise multiplication

--- a/src/Array.jl
+++ b/src/Array.jl
@@ -132,6 +132,8 @@ function Matrix{T}(g::Gate{<:SU{N}}) where {T, N}
     return g.array |> Matrix{T}
 end
 
+Array{T}(g::Gate{SU{N}}) where {T,N} = Array{T,2 * length(g)}(reshape(Matrix{T}(g), fill(2, 2 * Int(log2(N)))...))
+
 Array(x::Gate) = Array{ComplexF32}(x)
 Array(::Type{T}) where {T<:Gate} = Array{ComplexF32}(T)
 

--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -130,7 +130,7 @@ function svg(gate::Gate{Op, N, P}) where {Op, N, P}
         elseif lane == b
             __svg_block(texname(Op); top = false, bottom = true)
         elseif lane ∈ setdiff(lanes(gate), [a, b])
-            __svg_block(; top = false, bottom = false)
+            __svg_block(texname(Op); top = false, bottom = false)
         else
             __svg_cross()
         end

--- a/test/Array_test.jl
+++ b/test/Array_test.jl
@@ -118,6 +118,13 @@
             @test size(Array(Gate{Op})) == tuple(fill(2, N)...)
         end
 
+        # Special case for SU{N}
+        for N in [2, 4, 8]
+            n_qubits = Int(log2(N))
+            @test Array(rand(Gate{SU{N}}, 1:Int(log2(N))...)) isa Array{ComplexF32, 2*n_qubits}
+            @test size(Array(rand(Gate{SU{N}}, 1:Int(log2(N))...))) == tuple(fill(2, 2*n_qubits)...)
+        end
+
         for Op in [
             I,
             X,


### PR DESCRIPTION
### Summary
This PR fixes two small problems regarding the `SU{N}` operator introduced on PR #37. These issues were:

- The `Array{T}(g::Gate{SU{N}})` method was missing, which was causing problems when trying to run `Tenet.TensorNetwork(circ)` for a `circ` that contained `SU{N}`-type gates.
- For multi-qubit gates with more than two qubits, the gates that were not the first nor the last one did not have a label into the plot.
