### PR TITLE
Refactor `Gate`, `Operator` definitions

### DIFF
--- a/src/Algorithms.jl
+++ b/src/Algorithms.jl
@@ -47,7 +47,7 @@ function QuantumVolume(n, depth)
             q1 = permutation[i]
             q2 = permutation[i + 1]
 
-            push!(circuit, rand(SU{4}, q1, q2))
+            push!(circuit, rand(SU{2}, q1, q2))
         end
     end
 

--- a/src/Array.jl
+++ b/src/Array.jl
@@ -119,15 +119,6 @@ function Matrix{T}(g::Gate{<:Control}) where {T}
     return M
 end
 
-function Base.rand(::Type{SU{N}}, lanes::NTuple{M,Int}; eltype::Type = ComplexF64) where {N,M}
-    # keep unitary matrix Q from QR decomposition
-    q, _ = qr(rand(eltype, N, N))
-
-    SU{N}(lanes...; array = Matrix(q))
-end
-
-Base.rand(::Type{Gate{SU{N}}}, lanes::Integer...; kwargs...) where {N} = rand(SU{N}, lanes; kwargs...)
-
 function Matrix{T}(g::Gate{<:SU{N}}) where {T,N}
     return g.array |> Matrix{T}
 end

--- a/src/Gate.jl
+++ b/src/Gate.jl
@@ -35,7 +35,10 @@ operator(g::Gate) = g.operator
 parameters(::Type{<:Gate{Op}}) where {Op} = parameters(Op)
 parameters(g::Gate) = parameters(operator(g))
 
-Base.propertynames(::Type{<:Gate{Op}}) where {Op} = isparametric(Op) ? (keys(parameters(Op))...,) : ()
+ntnames(::NamedTuple{N,T}) where {N,T} = N
+ntnames(::Type{NamedTuple{N,T}}) where {N,T} = N
+
+Base.propertynames(::Type{<:Gate{Op}}) where {Op} = isparametric(Op) ? (ntnames(parameters(Op))...,) : ()
 Base.propertynames(::G) where {Op,G<:Gate{Op}} = isparametric(Op) ? propertynames(G) : ()
 Base.getproperty(g::Gate{Op}, i::Symbol) where {Op} = i ∈ propertynames(g) ? parameters(g)[i] : getfield(g, i)
 

--- a/src/Gate.jl
+++ b/src/Gate.jl
@@ -406,7 +406,7 @@ Base.rand(::Type{Op}) where {Op<:Operator} = isparametric(Op) ? Op(; randtuple(p
 Base.rand(::Type{Gate{Op}}, lanes::Integer...) where {Op} = Gate{Op}(lanes, rand(Op))
 
 function Base.rand(::Type{SU{N}}; eltype::Type = ComplexF64) where {N}
-    q, _ = qr(rand(eltype, N, N))
+    q, _ = qr(rand(eltype, 2^N, 2^N))
     SU{N}(; matrix = Matrix(q))
 end
 

--- a/src/Gate.jl
+++ b/src/Gate.jl
@@ -1,4 +1,4 @@
-export Gate, Operator
+export Gate
 export lanes
 export X, Y, Z, H, S, Sd, T, Td
 export isparametric, parameters
@@ -9,21 +9,111 @@ export CX, CY, CZ, CRx, CRy, CRz
 export control, target, operator
 export Pauli, Phase
 
-"""
-    Operator
+abstract type Operator end
 
-Parent type of quantum operators.
-"""
-abstract type Operator{Params<:NamedTuple} end
+isparametric(T::Type{<:Operator}) = !isnothing(parameters(T))
+isparametric(::T) where {T<:Operator} = isparametric(T)
 
-# NOTE useful type piracy
-Base.keys(::Type{<:NamedTuple{K}}) where {K} = K
+function parameters end
+function lanes end
 
-# `Operator` with no parameters
-const StaticOperator = Operator{NamedTuple{(),Tuple{}}}
+struct Gate{Op<:Operator,N}
+    lanes::NTuple{N,Int}
+    operator::Op
+end
 
-parameters(::Type{<:Operator{Params}}) where {Params} = Params
-isparametric(::Type{T}) where {T<:Operator} = parameters(T) !== NamedTuple{(),Tuple{}}
+Base.length(::Type{Gate{Op,N}}) where {Op,N} = N
+lanes(g::Gate) = g.lanes
+
+operator(::Type{<:Gate{Op}}) where {Op} = Op
+operator(g::Gate) = g.operator
+
+parameters(::Type{<:Gate{Op}}) where {Op} = parameters(Op)
+parameters(g::Gate) = parameters(operator(g))
+
+Base.propertynames(::Type{<:Gate{Op}}) where {Op} = (keys(parameters(Op))...,)
+Base.propertynames(::G) where {G<:Gate{Op}} where {Op} = propertynames(G)
+Base.getproperty(g::Gate{Op}, i::Symbol) where {Op} = i ∈ propertynames(g) ? parameters(g)[i] : getfield(g, i)
+
+Base.adjoint(::Type{Gate{Op,N}}) where {Op,N} = Gate{adjoint(Op),N}
+Base.adjoint(g::Gate{Op,N}) where {Op,N} = Gate{Op',N}(g.lanes, g.operator')
+
+function Base.summary(io::IO, gate::Gate)
+    Op = operator(gate)
+    Args = join(Iterators.flatten((lanes(gate), Iterators.map(x -> "$(x[1])=$(x[2])", pairs(parameters(gate))))), ",")
+    print(io, "$Op($Args)")
+end
+
+Base.show(io::IO, ::MIME"text/plain", gate::Gate) = summary(io, gate)
+
+macro gatedecl(name, opts...)
+    @assert Meta.isidentifier(name)
+
+    opts = collect(opts)
+    params = !isempty(opts) && Meta.isexpr(opts[end], :block) ? pop!(opts) : Expr(:block)
+    isparametric = !isempty(params.args)
+
+    # options
+    n = 1
+    adjoint = isparametric ? :parametric : :hermitian
+
+    for opt in opts
+        @assert Meta.isexpr(opt, :(=))
+        optname, optvalue = opt.args
+
+        if optname == :n
+            @assert optvalue isa Integer
+            n = optvalue
+        elseif optname == :adjoint
+            @assert optvalue isa Symbol
+            adjoint = optvalue
+        else
+            throw(ArgumentError("Invalid option $optname"))
+        end
+    end
+
+    # parameters code
+    code_parameters = if isparametric
+        local params = Base.remove_linenums!(params)
+        paramstuples = map(params.args) do arg
+            arg = Meta.isexpr(arg, :(=)) ? arg.args[1] : arg
+            @assert Meta.isexpr(arg, :(::))
+            tuple(arg.args...)
+        end
+        paramstuple = :(NamedTuple{($(QuoteNode.(first.(paramstuples))...),),Tuple{$(last.(paramstuples)...)}})
+        fieldaccesses = map(field -> :(op.$field), first.(paramstuples))
+        quote
+            $(esc(:(parameters(::Type{$name}) = $paramstuple)))
+            $(esc(:(parameters(op::$name) = $paramstuple($(fieldaccesses...)))))
+        end
+    else
+        quote
+            $(esc(:(parameters(::Type{$name}) = nothing)))
+            $(esc(:(parameters(::$name) = nothing)))
+        end
+    end
+
+    # adjoint code
+    code_adjoint = if adjoint == :hermitian
+        esc(:(Base.adjoint(op::$name) = op))
+    elseif adjoint == :parametric
+        esc(:(Base.adjoint(op::$name) = parameters(op)))
+    else
+        esc(:(Base.adjoint(::Type{$name}) = $adjoint()))
+    end
+
+    return quote
+        $(esc(:(Core.@__doc__ Base.@kwdef struct $name <: $Operator
+            $(params.args...)
+        end)))
+
+        $(esc(:($name(lanes...; params...) = Gate{$name,$n}(lanes, $name(params...)))))
+
+        $(esc(:(Base.length(::Type{$name}) = $n)))
+        $(code_parameters.args...)
+        $code_adjoint
+    end
+end
 
 """
     I(lane)
@@ -34,97 +124,109 @@ The ``σ_0`` Pauli matrix gate.
 
 Due to name clashes with `LinearAlgebra.I`, `Quac.I` is not exported by default.
 """
-abstract type I <: StaticOperator end
+@gatedecl I
 
 """
     X(lane)
 
 The ``σ_1`` Pauli matrix gate.
 """
-abstract type X <: StaticOperator end
+@gatedecl X
 
 """
     Y(lane)
 
 The ``σ_2`` Pauli matrix gate.
 """
-abstract type Y <: StaticOperator end
+@gatedecl Y
 
 """
     Z(lane)
 
 The ``σ_3`` Pauli matrix gate.
 """
-abstract type Z <: StaticOperator end
+@gatedecl Z
 
 """
     H(lane)
 
 The Hadamard gate.
 """
-abstract type H <: StaticOperator end
+@gatedecl H
 
 """
     S(lane)
 
 The ``S`` gate or ``\\frac{π}{2}`` rotation around Z-axis.
 """
-abstract type S <: StaticOperator end
+@gatedecl S adjoint = Sd
 
 """
     Sd(lane)
 
 The ``S^\\dagger`` gate or ``-\\frac{π}{2}`` rotation around Z-axis.
 """
-abstract type Sd <: StaticOperator end
+@gatedecl Sd adjoint = S
 
 """
     T(lane)
 
 The ``T`` gate or ``\\frac{π}{4}`` rotation around Z-axis.
 """
-abstract type T <: StaticOperator end
+@gatedecl T adjoint = Td
 
 """
     Td(lane)
 
 The ``T^\\dagger`` gate or ``-\\frac{π}{4}`` rotation around Z-axis.
 """
-abstract type Td <: StaticOperator end
+@gatedecl Td adjoint = T
 
-for Op in [:I, :X, :Y, :Z, :H, :S, :Sd, :T, :Td]
-    @eval Base.length(::Type{$Op}) = 1
-end
+Base.sqrt(::Type{Z}) = S
+Base.sqrt(::Type{S}) = T
+Base.sqrt(::Type{Sd}) = Td
 
 """
     Rx(lane, θ)
 
 The ``\\theta`` rotation around the X-axis gate.
 """
-abstract type Rx <: Operator{NamedTuple{(:θ,),Tuple{Float64}}} end
-Base.sqrt(::Type{X}) = (lane) -> Rx(lane, θ = π / 2)
+@gatedecl Rx begin
+    θ::Float64 = 0
+end
+
+Base.sqrt(::X) = Rx(θ = π / 2)
+Base.sqrt(op::Rx) = Rx(θ = op.θ / 2)
 
 """
     Rxx(lane1, lane2, θ)
 
 The ``\\theta`` rotation around the XX-axis gate.
 """
-abstract type Rxx <: Operator{NamedTuple{(:θ,),Tuple{Float64}}} end
+@gatedecl Rxx n = 2 begin
+    θ::Float64 = 0
+end
 
 """
     Ry(lane, θ)
 
 The ``\\theta`` rotation around the Y-axis gate.
 """
-abstract type Ry <: Operator{NamedTuple{(:θ,),Tuple{Float64}}} end
-Base.sqrt(::Type{Y}) = (lane) -> Ry(lane, θ = π / 2)
+@gatedecl Ry begin
+    θ::Float64 = 0
+end
+
+Base.sqrt(::Y) = Ry(θ = π / 2)
+Base.sqrt(::Ry) = Ry(θ = op.θ / 2)
 
 """
     Ryy(lane1, lane2, θ)
 
 The ``\\theta`` rotation around the YY-axis gate.
 """
-abstract type Ryy <: Operator{NamedTuple{(:θ,),Tuple{Float64}}} end
+@gatedecl Ryy n = 2 begin
+    θ::Float64 = 0
+end
 
 """
     Rz(lane, θ)
@@ -135,24 +237,24 @@ The ``\\theta`` rotation around the Z-axis gate.
 
   - The `U1` gate is an alias of `Rz`.
 """
-abstract type Rz <: Operator{NamedTuple{(:θ,),Tuple{Float64}}} end
-Base.sqrt(::Type{Z}) = S
-Base.sqrt(::Type{S}) = T
-Base.sqrt(::Type{Sd}) = Td
+@gatedecl Rz begin
+    θ::Float64 = 0
+end
+
+Base.sqrt(::Z) = S()
+Base.sqrt(::S) = T()
+Base.sqrt(::Sd) = Td()
+Base.sqrt(op::Rz) = Rz(θ = op.θ / 2)
+Base.sqrt(::T) = Rz(θ = π / 8)
+Base.sqrt(::Td) = Rz(θ = -π / 8)
 
 """
     Rzz(lane1, lane2, θ)
 
 The ``\\theta`` rotation around the ZZ-axis gate.
 """
-abstract type Rzz <: Operator{NamedTuple{(:θ,),Tuple{Float64}}} end
-
-for Op in [:Rx, :Ry, :Rz]
-    @eval Base.length(::Type{$Op}) = 1
-end
-
-for Op in [:Rxx, :Ryy, :Rzz]
-    @eval Base.length(::Type{$Op}) = 2
+@gatedecl Rzz n = 2 begin
+    θ::Float64 = 0
 end
 
 const U1 = Rz
@@ -162,154 +264,76 @@ const U1 = Rz
 
 The ``U2`` gate.
 """
-abstract type U2 <: Operator{NamedTuple{(:ϕ, :λ),Tuple{Float64,Float64}}} end
-Base.length(::Type{U2}) = 1
+@gatedecl U2 begin
+    ϕ::Float64 = 0
+    λ::Float64 = 0
+end
 
 """
     U3(lane, θ, ϕ, λ)
 
 The ``U3`` gate.
 """
-abstract type U3 <: Operator{NamedTuple{(:θ, :ϕ, :λ),Tuple{Float64,Float64,Float64}}} end
-Base.length(::Type{U3}) = 1
+@gatedecl U3 begin
+    θ::Float64 = 0
+    ϕ::Float64 = 0
+    λ::Float64 = 0
+end
 
 """
     Hz(lane, θ, ϕ)
 
 The Hz (PhasedXPow) gate, equivalent to ``Z^ϕ X^θ Z^{-ϕ}``.
 """
-abstract type Hz <: Operator{NamedTuple{(:θ, :ϕ),Tuple{Float64,Float64}}} end
-Base.length(::Type{Hz}) = 1
+@gatedecl Hz begin
+    θ::Float64 = 0
+    ϕ::Float64 = 0
+end
 
 """
     Swap(lane1, lane2)
 
 The SWAP gate.
 """
-abstract type Swap <: StaticOperator end
-Base.length(::Type{Swap}) = 2
+@gatedecl Swap n = 2
 
 """
     FSim(lane1, lane2, θ, ϕ)
 
 The FSim (Fermionic Simulation) gate.
 """
-abstract type FSim <: Operator{NamedTuple{(:θ, :ϕ),Tuple{Float64,Float64}}} end
-Base.length(::Type{FSim}) = 2
+@gatedecl FSim n = 2 begin
+    θ::Float64 = 0
+    ϕ::Float64 = 0
+end
 
 """
     Control(lane, op::Gate)
 
 A controlled gate.
 """
-abstract type Control{Op<:Operator} <: Operator{NamedTuple{(:target,),Tuple{Operator}}} end
+Base.@kwdef struct Control{Op<:Operator} <: Operator
+    target::Op
+end
+
+Control{Op}(lanes...; params...) where {Op} = Gate{Control{Op},length(lanes)}(lanes...; params...)
+Control(lane, op::Gate{Op,N}) where {Op,N} = Gate{Control{Op},N + 1}(lane, lanes(op)...; parameters(op)...)
+
 Base.length(::Type{Control{T}}) where {T<:Operator} = 1 + length(T)
+isparametric(::Type{<:Control{T}}) where {T<:Operator} = isparametric(T)
 parameters(::Type{Control{Op}}) where {Op} = parameters(Op)
 
-"""
-    SU(N)(lane_1, lane_2, ..., lane_log2(N))
-
-The `SU{N}` multi-qubit general unitary gate that can be used to represent any unitary matrix that acts on
-`log2(N)` qubits. A new random `SU{N}` can be created with `rand(SU{N}, lanes...)`, where `N` is the dimension
- of the unitary matrix and `lanes` are the qubit lanes on which the gate acts.
-"""
-abstract type SU{N} <: Operator{NamedTuple{(:array,), Tuple{Matrix}}} end
-Base.length(::Type{SU{N}}) where {N} =
-    ispow2(N) ? log2(N) |> Int : throw(DomainError(N, "N must be a power of 2"))
+Base.adjoint(::Type{Control{Op}}) where {Op} = Control{adjoint(Op)}
+Base.adjoint(op::Control{Op}) where {Op} =
+    if isparametric(op)
+        Control{Op'}([key => -val for (key, val) in pairs(parameters(op))]...)
+    else
+        Control{adjoint(Op)}()
+    end
 
 for Op in [:X, :Y, :Z, :Rx, :Ry, :Rz]
     @eval const $(Symbol("C" * String(Op))) = Control{$Op}
 end
-
-# adjoints
-for Op in [:I, :X, :Y, :Z, :Rx, :Ry, :Rz, :Rxx, :Ryy, :Rzz, :U2, :U3, :H, :Swap, :FSim]
-    @eval Base.adjoint(::Type{$Op}) = $Op
-end
-
-Base.adjoint(::Type{S}) = Sd
-Base.adjoint(::Type{Sd}) = S
-Base.adjoint(::Type{T}) = Td
-Base.adjoint(::Type{Td}) = T
-
-Base.adjoint(::Type{Control{Op}}) where {Op} = Control{adjoint(Op)}
-
-# operator sets
-const Pauli = Union{I,X,Y,Z}
-const Phase = Union{I,Z,S,Sd,T,Td,Rz,Hz,FSim}
-
-"""
-    Gate{Operator}(lanes...; parameters...)
-
-An `Operator` located at some `lanes` and configured with some `parameters`.
-"""
-struct Gate{Op<:Operator,N,Params}
-    lanes::NTuple{N,Int}
-    parameters::Params
-
-    function Gate{Op}(lanes...; params...) where {Op<:Operator}
-        N = length(Op)
-        P = parameters(Op)
-        params = NamedTuple{tuple(keys(params)...),Tuple{typeof.(collect(values(params)))...}}((values(params)...,))
-        new{Op,N,P}(lanes, params)
-    end
-end
-
-# constructor aliases
-for Op in [:I, :X, :Y, :Z, :H, :S, :Sd, :T, :Td, :U2, :U3, :Rx, :Ry, :Rz, :Rxx, :Ryy, :Rzz, :Swap, :Hz, :FSim]
-    @eval $Op(lanes...; params...) = Gate{$Op}(lanes...; params...)
-end
-
-function SU{N}(lanes...; array::Matrix) where {N}
-    ispow2(N) || throw(DomainError(N, "N must be a power of 2"))
-    2^length(lanes) == N || throw(ArgumentError("SU{$N} requires $(log2(N) |> Int) lanes"))
-    size(array) == (N,N) || throw(ArgumentError("`array` must be a (N,N)-size matrix"))
-    isapprox(array * adjoint(array), Matrix{ComplexF64}(LinearAlgebra.I, N, N)) || throw(ArgumentError("`array` is not unitary"))
-
-    Gate{SU{N}}(lanes...; array)
-end
-
-Base.sqrt(g::Gate{X}) = Rx(lanes(g)..., θ = π / 2)
-Base.sqrt(g::Gate{Y}) = Ry(lanes(g)..., θ = π / 2)
-Base.sqrt(g::Gate{Z}) = S(lanes(g)...)
-Base.sqrt(g::Gate{S}) = T(lanes(g)...)
-Base.sqrt(g::Gate{Sd}) = Td(lanes(g)...)
-
-Control{Op}(lanes...; params...) where {Op} = Gate{Control{Op}}(lanes...; params...)
-Control(lane, op::Gate{Op}) where {Op} = Gate{Control{Op}}(lane, lanes(op)...; parameters(op)...)
-
-lanes(g::Gate) = g.lanes
-Base.length(::Type{Gate{Op}}) where {Op} = length(Op)
-Base.length(::Gate{Op}) where {Op} = length(Op)
-operator(::Type{<:Gate{Op}}) where {Op} = Op
-operator(::Gate{Op}) where {Op} = operator(Gate{Op})
-
-function Base.summary(io::IO, gate::Gate)
-    flatten = Iterators.flatten
-    map = Iterators.map
-
-    Op = operator(gate)
-    Args = join(flatten((lanes(gate), map(x -> "$(x[1])=$(x[2])", pairs(parameters(gate))))), ",")
-    print(io, "$Op($Args)")
-end
-
-Base.show(io::IO, ::MIME"text/plain", gate::Gate) = summary(io, gate)
-
-parameters(g::Gate) = g.parameters
-parameters(::Type{<:Gate{Op}}) where {Op} = parameters(Op)
-Base.propertynames(::Type{<:Gate{Op}}) where {Op} = (keys(parameters(Op))...,)
-Base.propertynames(::G) where {G<:Gate{Op}} where {Op} = propertynames(G)
-Base.getproperty(g::Gate{Op}, i::Symbol) where {Op} = i ∈ propertynames(g) ? parameters(g)[i] : getfield(g, i)
-
-Base.adjoint(::Type{<:Gate{Op}}) where {Op} = Gate{adjoint(Op)}
-Base.adjoint(::Type{Gate{Op,N,P}}) where {Op,N,P} = Gate{adjoint(Op),N,P}
-Base.adjoint(g::Gate{Op}) where {Op} = Gate{Op'}(lanes(g)...; [key => -val for (key, val) in pairs(parameters(g))]...)
-Base.adjoint(g::Gate{SU{N}}) where {N} = Gate{SU{N}}(lanes(g)...; array = adjoint(g.array))
-
-# NOTE useful type piracy
-Base.rand(::Type{NamedTuple{N,T}}) where {N,T} = NamedTuple{N}(rand(type) for type in T.parameters)
-
-Base.rand(::Type{Op}) where {Op<:Operator} = rand(parameters(Op))
-Base.rand(::Type{Gate{Op}}, lanes::Integer...) where {Op} = Gate{Op}(lanes...; rand(Op)...)
 
 # Gate{Control}
 targettype(::Type{Op}) where {Op<:Operator} = Op
@@ -319,3 +343,46 @@ targettype(::Type{<:Gate{Op}}) where {Op} = targettype(Op)
 
 control(g::G) where {G<:Gate{<:Control}} = lanes(g)[1:end-length(targettype(G))]
 target(g::G) where {G<:Gate{<:Control}} = lanes(g)[end-length(targettype(G))+1:end]
+
+"""
+    SU{N}(lane_1, lane_2, ..., lane_N, array)
+
+The `SU{N}` multi-qubit general unitary gate that can be used to represent any unitary matrix that acts on
+`N` qubits. A new random `SU{N}` can be created with `rand(SU{N}, lanes...)`, where `N` is the dimension
+of the unitary matrix and `lanes` are the qubit lanes on which the gate acts.
+
+# Note
+
+Unlike the general notation, `N` is not the dimension of the unitary matrix, but the number of qubits on which it acts.
+The dimension of the unitary matrix is ``2^N \\times 2^N``.
+"""
+struct SU{N} <: Operator
+    matrix::Matrix
+
+    function SU{N}(; matrix) where {N}
+        size(matrix) == (2^N, 2^N) || throw(ArgumentError("`matrix` ($(size(matrix))) must be a (2^N,2^N)-size matrix"))
+        LinearAlgebra.det(matrix) ≈ 1 || throw(ArgumentError("`matrix` is not unitary"))
+        new(matrix)
+    end
+end
+
+function SU{N}(lanes...; params...) where {N}
+    length(lanes) == N || throw(ArgumentError("SU{$N} requires $N lanes"))
+    Gate{SU{N},N}(lanes, SU{N}(; params...))
+end
+
+Base.length(::Type{SU{N}}) where {N} = N
+isparametric(::Type{<:SU}) = true
+parameters(::Type{SU{N}}) where {N} = NamedTuple{(:matrix),Tuple{Matrix}}
+
+Base.adjoint(::Type{SU{N}}) where {N} = SU{N}
+Base.adjoint(op::SU{N}) where {N} = SU{N}(; matrix = op.matrix')
+
+# operator sets
+const Pauli = Union{I,X,Y,Z}
+const Phase = Union{I,Z,S,Sd,T,Td,Rz}
+
+randtuple(::Type{NamedTuple{N,T}}) where {N,T} = NamedTuple{N}(rand(type) for type in T.parameters)
+
+Base.rand(::Type{Op}) where {Op<:Operator} = randtuple(parameters(Op))
+Base.rand(::Type{Gate{Op}}, lanes::Integer...) where {Op} = Gate{Op}(lanes...; rand(Op)...)

--- a/src/Gate.jl
+++ b/src/Gate.jl
@@ -402,7 +402,7 @@ const Phase = Union{I,Z,S,Sd,T,Td,Rz}
 randtuple(::Type{NamedTuple{N,T}}) where {N,T} = NamedTuple{N}(rand(type) for type in T.parameters)
 
 Base.rand(::Type{Op}) where {Op<:Operator} = isparametric(Op) ? Op(; randtuple(parameters(Op))...) : Op()
-Base.rand(::Type{Gate{Op}}, lanes::Integer...) where {Op} = Gate{Op}(lanes...; rand(Op)...)
+Base.rand(::Type{Gate{Op}}, lanes::Integer...) where {Op} = Gate{Op}(lanes, rand(Op))
 
 function Base.rand(::Type{SU{N}}; eltype::Type = ComplexF64) where {N}
     q, _ = qr(rand(eltype, N, N))

--- a/src/Gate.jl
+++ b/src/Gate.jl
@@ -25,6 +25,7 @@ end
 Gate{Op,N}(lanes...; params...) where {Op,N} = Gate{Op,N}(lanes, Op(params...))
 
 Base.length(::Type{Gate{Op,N}}) where {Op,N} = N
+Base.length(::Type{Gate{Op}}) where {Op} = length(Op)
 lanes(g::Gate) = g.lanes
 
 operator(::Type{<:Gate{Op}}) where {Op} = Op

--- a/src/Gate.jl
+++ b/src/Gate.jl
@@ -332,8 +332,11 @@ Control{Op}(lane, lanes::Vararg{Int,N}; params...) where {Op,N} =
     Gate{Control{Op},N + 1}(tuple(lane, lanes...), Control{Op}(; params...))
 
 Base.length(::Type{Control{T}}) where {T<:Operator} = 1 + length(T)
+
 isparametric(::Type{<:Control{T}}) where {T<:Operator} = isparametric(T)
+isparametric(op::Control{T}) where {T<:Operator} = isparametric(T)
 parameters(::Type{Control{Op}}) where {Op} = parameters(Op)
+parameters(op::Control{Op}) where {Op} = parameters(op.target)
 
 Base.adjoint(::Type{Control{Op}}) where {Op} = Control{adjoint(Op)}
 Base.adjoint(op::Control{Op}) where {Op} =
@@ -385,7 +388,9 @@ end
 
 Base.length(::Type{SU{N}}) where {N} = N
 isparametric(::Type{<:SU}) = true
-parameters(::Type{SU{N}}) where {N} = NamedTuple{(:matrix),Tuple{Matrix}}
+isparametric(::SU) = true
+parameters(::Type{SU{N}}) where {N} = NamedTuple{(:matrix,),Tuple{Matrix}}
+parameters(op::SU{N}) where {N} = (; matrix = op.matrix)
 
 Base.adjoint(::Type{SU{N}}) where {N} = SU{N}
 Base.adjoint(op::SU{N}) where {N} = SU{N}(; matrix = op.matrix')

--- a/src/Gate.jl
+++ b/src/Gate.jl
@@ -33,8 +33,8 @@ operator(g::Gate) = g.operator
 parameters(::Type{<:Gate{Op}}) where {Op} = parameters(Op)
 parameters(g::Gate) = parameters(operator(g))
 
-Base.propertynames(::Type{<:Gate{Op}}) where {Op} = (keys(parameters(Op))...,)
-Base.propertynames(::G) where {G<:Gate{Op}} where {Op} = propertynames(G)
+Base.propertynames(::Type{<:Gate{Op}}) where {Op} = isparametric(Op) ? (keys(parameters(Op))...,) : ()
+Base.propertynames(::G) where {Op,G<:Gate{Op}} = isparametric(Op) ? propertynames(G) : ()
 Base.getproperty(g::Gate{Op}, i::Symbol) where {Op} = i ∈ propertynames(g) ? parameters(g)[i] : getfield(g, i)
 
 Base.adjoint(::Type{Gate{Op,N}}) where {Op,N} = Gate{adjoint(Op),N}

--- a/src/Gate.jl
+++ b/src/Gate.jl
@@ -42,6 +42,7 @@ Base.propertynames(::Type{<:Gate{Op}}) where {Op} = isparametric(Op) ? (ntnames(
 Base.propertynames(::G) where {Op,G<:Gate{Op}} = isparametric(Op) ? propertynames(G) : ()
 Base.getproperty(g::Gate{Op}, i::Symbol) where {Op} = i ∈ propertynames(g) ? parameters(g)[i] : getfield(g, i)
 
+Base.adjoint(::Type{Gate{Op}}) where {Op} = Gate{Op',length(Op)}
 Base.adjoint(::Type{Gate{Op,N}}) where {Op,N} = Gate{adjoint(Op),N}
 Base.adjoint(g::Gate{Op,N}) where {Op,N} = Gate{Op',N}(g.lanes, g.operator')
 

--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -118,9 +118,9 @@ function svg(circuit::Circuit; kwargs...)
     return drawing
 end
 
-svg(gate::Gate{Op,1,P}) where {Op,P} = __svg_block(; top = false, bottom = false)
+svg(::Gate{Op,1}) where {Op} = __svg_block(; top = false, bottom = false)
 
-function svg(gate::Gate{Op, N, P}) where {Op, N, P}
+function svg(gate::Gate{Op,N}) where {Op,N}
     a, b = extrema(lanes(gate))
     r = a:b
 
@@ -139,11 +139,11 @@ function svg(gate::Gate{Op, N, P}) where {Op, N, P}
     return __svg_vcat_blocks(blocks...)
 end
 
-svg(::Gate{I,1,NamedTuple{(),Tuple{}}}) =
+svg(::Gate{I,1}) =
     h.svg(h.line."wire lane"(; x1 = -25, y1 = 0, x2 = 25, y2 = 0), viewBox = "-25 -25 50 50", width = 50, height = 50)
 
 for Op in [X, Y, Z, H, S, Sd, T, Td, Rx, Ry, Rz, Hz, FSim]
-    @eval svg(::Gate{$Op,1,P}; kwargs...) where {P} = __svg_block(texname($Op); kwargs...)
+    @eval svg(::Gate{$Op,1}; kwargs...) = __svg_block(texname($Op); kwargs...)
 end
 
 function svg(gate::Gate{<:Control}; kwargs...)

--- a/test/Gate_test.jl
+++ b/test/Gate_test.jl
@@ -38,16 +38,15 @@
 
     @testset "Constructor" begin
         for Op in [I, X, Y, Z, H, S, Sd, T, Td, Rx, Ry, Rz, Rxx, Ryy, Rzz, U2, U3]
-            @test Gate{Op}(range(1, length = length(Op))...; rand(parameters(Op))...) !== nothing
+            N = length(Op)
+            @test Gate{Op}(1:N...; Quac.randtuple(parameters(Op))...) |> !isnothing
         end
 
         # Special case for SU{N}
-       for N in [2, 4, 8]
-            _lanes = range(1, length = log2(N) |> Int)
-            rand_matrix = rand(ComplexF32, N, N)
-            q, _ = qr(rand_matrix)
-            array = Matrix{ComplexF32}(q)
-            @test Gate{SU{N}}(_lanes...; array = array) !== nothing
+        for N in [2, 4, 8]
+            q, _ = qr(rand(ComplexF32, 2^N, 2^N))
+            matrix = Matrix{ComplexF32}(q)
+            @test Gate{SU{N}}(1:N...; matrix) |> !isnothing
         end
     end
 
@@ -83,17 +82,14 @@
             Control{Control{Control{Swap}}},
         ]
             N = length(Op)
-            P = parameters(Op)
-            @test Op(1:N...; rand(P)...) isa Gate{Op,N,P}
+            @test Op(1:N...; Quac.randtuple(parameters(Op))...) isa Gate{Op,N}
         end
 
         # Special case for SU{N}
         for N in [2, 4, 8]
-            _lanes = range(1, length = log2(N) |> Int)
-            rand_matrix = rand(ComplexF64, N, N)
-            q, _ = qr(rand_matrix)
-            array = Matrix{ComplexF64}(q)
-            @test SU{N}(_lanes...; array = array) isa Gate{SU{N},log2(N) |> Int, NamedTuple{(:array,),Tuple{Matrix}}}
+            q, _ = qr(rand(ComplexF64, 2^N, 2^N))
+            matrix = Matrix{ComplexF64}(q)
+            @test SU{N}(1:N...; matrix) isa Gate{SU{N},N}
         end
     end
 

--- a/test/Gate_test.jl
+++ b/test/Gate_test.jl
@@ -212,19 +212,17 @@
         ]
             @test parameters(Gate{Op}) === parameters(Op)
 
-            params = rand(parameters(Op))
-            @test parameters(Gate{Op}(1:length(Op)...; params...)) === params
+            params = Quac.randtuple(parameters(Op))
+            @test parameters(Gate{Op}(1:length(Op)...; params...)) == params
         end
 
         # Special case for SU{N}
         for N in [2, 4, 8]
             @test parameters(Gate{SU{N}}) === parameters(SU{N})
 
-            _lanes = 1:length(SU{N}) |> collect
-            rand_matrix = rand(ComplexF32, N, N)
-            q, _ = qr(rand_matrix)
-            array = Matrix{ComplexF32}(q)
-            @test parameters(Gate{SU{N}}(_lanes...; array = array)).array === array
+            q, _ = qr(rand(ComplexF32, 2^N, 2^N))
+            matrix = Matrix{ComplexF32}(q)
+            @test parameters(Gate{SU{N}}(1:N...; matrix)).matrix == matrix
         end
     end
 

--- a/test/Gate_test.jl
+++ b/test/Gate_test.jl
@@ -32,7 +32,7 @@
             SU{2},
             SU{4},
         ]
-            @test length(Gate{Op}) === length(Op)
+            @test length(Gate{Op}) == length(Op)
         end
     end
 

--- a/test/Gate_test.jl
+++ b/test/Gate_test.jl
@@ -353,9 +353,9 @@
             Control{Swap},
             Control{Control{Swap}},
             Control{Control{Control{Swap}}},
+            SU{1},
             SU{2},
-            SU{4},
-            SU{8},
+            SU{3},
         ]
             @test Quac.ntnames(parameters(Op)) ⊆ propertynames(Gate{Op})
 

--- a/test/Gate_test.jl
+++ b/test/Gate_test.jl
@@ -319,8 +319,7 @@
             SU{8},
         ]
             N = length(Op)
-            P = parameters(Op)
-            @test rand(Gate{Op}, 1:N...) isa Gate{Op,N,P}
+            @test rand(Gate{Op}, 1:N...) isa Gate{Op,N}
         end
     end
 

--- a/test/Gate_test.jl
+++ b/test/Gate_test.jl
@@ -124,16 +124,15 @@
             Control{Control{Swap}},
             Control{Control{Control{Swap}}},
         ]
-            @test lanes(Gate{Op}(1:length(Op)...; rand(parameters(Op))...)) === tuple(1:length(Op)...)
+            N = length(Op)
+            @test lanes(Gate{Op}(1:N...; Quac.randtuple(parameters(Op))...)) === tuple(1:N...)
         end
 
         # Special case for SU{N}
         for N in [2, 4, 8]
-            _lanes = 1:length(SU{N}) |> collect
-            rand_matrix = rand(ComplexF32, N, N)
-            q, _ = qr(rand_matrix)
-            array = Matrix{ComplexF32}(q)
-            @test lanes(Gate{SU{N}}(_lanes...; array = array)) === tuple(1:length(SU{N})...)
+            q, _ = qr(rand(ComplexF32, 2^N, 2^N))
+            matrix = Matrix{ComplexF32}(q)
+            @test lanes(Gate{SU{N}}(1:N...; matrix)) === tuple(1:length(SU{N})...)
         end
     end
 

--- a/test/Gate_test.jl
+++ b/test/Gate_test.jl
@@ -257,30 +257,30 @@
             Control{Control{Swap}},
             Control{Control{Control{Swap}}},
         ]
-            @test adjoint(Gate{Op}) === Gate{adjoint(Op)}
+            @test adjoint(Gate{Op}) === Gate{adjoint(Op),length(Op)}
         end
 
         # `adjoint(::Gate)` with no parameters
         for Op in [I, X, Y, Z, H, S, Sd, T, Td, Swap, Control{I}, Control{Control{I}}, Control{Control{Control{I}}}]
-            @test adjoint(Gate{Op}(1:length(Op)...)) === Gate{adjoint(Op)}(1:length(Op)...)
+            N = length(Op)
+            @test adjoint(Gate{Op}(1:N...)) === Gate{adjoint(Op),N}(1:N...)
         end
 
         # `adjoint(::Gate)` with parameters
         for Op in [Rx, Ry, Rz, Rxx, Ryy, Rzz, U2, U3, Control{Rx}, Control{Control{Rx}}, Control{Control{Control{Rx}}}]
-            params = rand(parameters(Op))
-            @test adjoint(Gate{Op}(1:length(Op)...; params...)) ===
-                  Gate{adjoint(Op)}(1:length(Op)...; [key => -val for (key, val) in pairs(params)]...)
+            params = Quac.randtuple(parameters(Op))
+            N = length(Op)
+            @test adjoint(Gate{Op}(1:N...; params...)) ===
+                  Gate{adjoint(Op),N}(1:N...; [key => -val for (key, val) in pairs(params)]...)
         end
 
         # Special case for SU{N}
         for N in [2, 4, 8]
             @test_throws MethodError adjoint(Gate{SU{N}})
 
-            _lanes = 1:length(SU{N}) |> collect
-            rand_matrix = rand(ComplexF64, N, N)
-            q, _ = qr(rand_matrix)
+            q, _ = qr(rand(ComplexF64, 2^N, 2^N))
 
-            @test adjoint(SU{N}(_lanes...; array = Matrix{ComplexF64}(q))).array == adjoint(Matrix{ComplexF64}(q))
+            @test adjoint(SU{N}(1:N...; matrix = Matrix{ComplexF64}(q))).matrix == adjoint(Matrix{ComplexF64}(q))
         end
     end
 

--- a/test/Gate_test.jl
+++ b/test/Gate_test.jl
@@ -168,16 +168,14 @@
             Control{Control{Control{Swap}}},
         ]
             # NOTE `operator(Gate{Op})` is implied
-            @test operator(Gate{Op}(1:length(Op)...; rand(parameters(Op))...)) === Op
+            @test operator(Gate{Op}(1:length(Op)...; Quac.randtuple(parameters(Op))...)) isa Op
         end
 
         # Special case for SU{N}
         for N in [2, 4, 8]
-            _lanes = 1:length(SU{N}) |> collect
-            rand_matrix = rand(ComplexF32, N, N)
-            q, _ = qr(rand_matrix)
-            array = Matrix{ComplexF32}(q)
-            @test operator(Gate{SU{N}}(_lanes...; array = array)) === SU{N}
+            q, _ = qr(rand(ComplexF32, 2^N, 2^N))
+            matrix = Matrix{ComplexF32}(q)
+            @test operator(Gate{SU{N}}(1:N...; array = array)) isa SU{N}
         end
     end
 

--- a/test/Gate_test.jl
+++ b/test/Gate_test.jl
@@ -401,21 +401,20 @@
 
     @testset "random unitary" begin
         # test_throws on a non-unitary matrix
-        @test_throws ArgumentError SU{4}(1, 2; array = rand(ComplexF32, 4, 4))
+        @test_throws ArgumentError SU{2}(1, 2; matrix = rand(ComplexF32, 4, 4))
 
         # test_throws on a non-square matrix
-        @test_throws ArgumentError SU{4}(1, 2; array = rand(ComplexF32, 4, 2))
+        @test_throws ArgumentError SU{2}(1, 2; matrix = rand(ComplexF32, 4, 2))
 
         # test_throws on a matrix without size (N, N)
-        @test_throws ArgumentError SU{4}(1, 2; array = rand(ComplexF32, 2, 2))
+        @test_throws ArgumentError SU{2}(1, 2; matrix = rand(ComplexF32, 2, 2))
 
         # test_throws SU{N} with N not a power of 2
-        @test_throws DomainError SU{3}(1, 2; array = rand(ComplexF32, 3, 3))
+        @test_throws ArgumentError SU{2}(1, 2; matrix = rand(ComplexF32, 3, 3))
 
-        # test_throws when there are not log2(N) lanes
-        rand_matrix = rand(ComplexF32, 4, 4)
-        q, _ = qr(rand_matrix)
-        @test_throws ArgumentError SU{4}(1, 2, 3; array = Matrix{ComplexF32}(q))
+        # test_throws when there are not N lanes
+        q, _ = qr(rand(ComplexF32, 4, 4))
+        @test_throws ArgumentError SU{3}(1, 2, 3; matrix = Matrix{ComplexF32}(q))
     end
 
     @testset "target" begin

--- a/test/Gate_test.jl
+++ b/test/Gate_test.jl
@@ -357,10 +357,10 @@
             SU{4},
             SU{8},
         ]
-            @test keys(parameters(Op)) ⊆ propertynames(Gate{Op})
+            @test Quac.ntnames(parameters(Op)) ⊆ propertynames(Gate{Op})
 
             N = length(Op)
-            @test keys(parameters(Op)) ⊆ propertynames(rand(Gate{Op}, 1:N...))
+            @test Quac.ntnames(parameters(Op)) ⊆ propertynames(rand(Gate{Op}, 1:N...))
         end
     end
 

--- a/test/Operator_test.jl
+++ b/test/Operator_test.jl
@@ -1,7 +1,5 @@
 @testset "Operator" begin
-    using Quac: I, StaticOperator
-
-    NoParameters = parameters(StaticOperator)
+    using Quac: I
 
     @testset "isparametric" begin
         for Op in [I, X, Y, Z, H, S, Sd, T, Td, Swap, Control{I}, Control{Control{I}}, Control{Control{Control{I}}}]
@@ -33,16 +31,16 @@
 
     @testset "Base.adjoint" begin
         for Op in [I, X, Y, Z, H, Rx, Ry, Rz, Swap, Control{I}, Control{Control{I}}, Control{Control{Control{I}}}]
-            @test adjoint(Op) === Op
+            @test adjoint(Op()) === Op()
         end
 
-        @test adjoint(S) == Sd
-        @test adjoint(Sd) == S
-        @test adjoint(T) == Td
-        @test adjoint(Td) == T
-        @test adjoint(Control{S}) === Control{Sd}
-        @test adjoint(Control{Control{S}}) === Control{Control{Sd}}
-        @test adjoint(Control{Control{Control{S}}}) === Control{Control{Control{Sd}}}
+        @test adjoint(S()) == Sd()
+        @test adjoint(Sd()) == S()
+        @test adjoint(T()) == Td()
+        @test adjoint(Td()) == T()
+        @test adjoint(Control{S}()) === Control{Sd}()
+        @test adjoint(Control{Control{S}}()) === Control{Control{Sd}}()
+        @test adjoint(Control{Control{Control{S}}}()) === Control{Control{Control{Sd}}}()
     end
 
     @testset "Base.rand" begin
@@ -70,7 +68,7 @@
             Control{Control{Swap}},
             Control{Control{Control{Swap}}},
         ]
-            @test rand(Op) isa parameters(Op)
+            @test rand(Op) isa Op
         end
     end
 

--- a/test/Operator_test.jl
+++ b/test/Operator_test.jl
@@ -31,7 +31,7 @@
 
     @testset "Base.adjoint" begin
         for Op in [I, X, Y, Z, H, Rx, Ry, Rz, Swap, Control{I}, Control{Control{I}}, Control{Control{Control{I}}}]
-            @test adjoint(Op()) === Op()
+            @test adjoint(Op()) isa Op
         end
 
         @test adjoint(S()) == Sd()


### PR DESCRIPTION
This PR refactors the `Gate` and `Operator` definitions. The difference gate types (e.g. `X`, `Swap`, `Ry`, `CZ`, ...) are still `Operator` subtypes, but now they are **concrete** subtypes that implement the parameters in their fields (unlike before, where parameters where encoded as a generic parameter of the `Gate` type).

This change lets us create operators without assigning the site they are acting on, which should be sufficient for retrieving the array representations or some other information. With this change, the `Gate` and `Operator` types have more clear semantics: A `Gate` is an `Operator` acting somewhere (i.e. has `sites`).

It also provides a small macro utility `@gatedecl` for declaring gate types.

Closes #44 