### PR TITLE
Add missing `Array{T,M}` method for `SU{N}` gate

### DIFF
--- a/src/Array.jl
+++ b/src/Array.jl
@@ -194,6 +194,7 @@ Array{T}(op::Op) where {T,Op<:Control} = Array{T,2 * length(Op)}(op)
 Array{T,N}(op::Control) where {T,N} = Array{T,N}(reshape(Matrix{T}(op), fill(2, N)...))
 
 Array{T}(op::SU{N}) where {T,N} = Array{T,2N}(reshape(Matrix{T}(op), fill(2, 2N)...))
+Array{T, M}(op::SU{N}) where {T, N, M} = (@assert M == 2 * N "M must be exactly 2 * N"; Array{T, 2N}(reshape(Matrix{T}(op), fill(2, 2N)...)))
 
 # diagonal matrices
 # NOTE efficient multiplication due to no memory swap needed: plain element-wise multiplication

--- a/src/Array.jl
+++ b/src/Array.jl
@@ -33,7 +33,7 @@ arraytype(::Swap) = Array{Bool,4}
 arraytype(::ISwap) = Array{Complex{Bool},4}
 arraytype(::FSwap) = Array{Int,4}
 
-arraytype(::SU{N}) where {N} = Array{ComplexF64,2N}
+arraytype(::SU{N}) where {N} = Array{ComplexF64}
 
 arraytype(op::Control) = Array{ComplexF64,2 * length(op)}
 
@@ -194,7 +194,6 @@ Array{T}(op::Op) where {T,Op<:Control} = Array{T,2 * length(Op)}(op)
 Array{T,N}(op::Control) where {T,N} = Array{T,N}(reshape(Matrix{T}(op), fill(2, N)...))
 
 Array{T}(op::SU{N}) where {T,N} = Array{T,2N}(reshape(Matrix{T}(op), fill(2, 2N)...))
-Array{T, M}(op::SU{N}) where {T, N, M} = (@assert M == 2 * N "M must be exactly 2 * N"; Array{T, 2N}(reshape(Matrix{T}(op), fill(2, 2N)...)))
 
 # diagonal matrices
 # NOTE efficient multiplication due to no memory swap needed: plain element-wise multiplication


### PR DESCRIPTION
This PR fixes [issue 33](https://github.com/bsc-quantic/Qrochet.jl/issues/33) in `Qrochet`, by adding the proper `Array{T,M}` method for `SU{N}` gate. This method was missing since `SU{N}` gate has its `arraytype` defined by:
```julia
arraytype(::SU{N}) where {N} = Array{ComplexF64,2N}
```