### PR TITLE
Fix value of `Y` gate

### DIFF
--- a/src/Array.jl
+++ b/src/Array.jl
@@ -194,7 +194,6 @@ Array{T}(op::Op) where {T,Op<:Control} = Array{T,2 * length(Op)}(op)
 Array{T,N}(op::Control) where {T,N} = Array{T,N}(reshape(Matrix{T}(op), fill(2, N)...))
 
 Array{T}(op::SU{N}) where {T,N} = Array{T,2N}(reshape(Matrix{T}(op), fill(2, 2N)...))
-Array{T,M}(op::SU{N}) where {T,N,M} = (M == 2*N) ?  Array{T,2N}(reshape(Matrix{T}(op), fill(2, 2N)...)) : throw(ArgumentError("Invalid dimensions"))
 
 # diagonal matrices
 # NOTE efficient multiplication due to no memory swap needed: plain element-wise multiplication

--- a/src/Array.jl
+++ b/src/Array.jl
@@ -48,7 +48,7 @@ Matrix(x::Operator) = Matrix{ComplexF64}(x)
 
 Matrix{T}(::I) where {T} = Matrix{T}(LinearAlgebra.I, 2, 2)
 Matrix{T}(::X) where {T} = Matrix{T}([0 1; 1 0])
-Matrix{T}(::Y) where {T} = Matrix{T}([0 -1; 1 0])
+Matrix{T}(::Y) where {T} = Matrix{T}([0 -1im; 1im 0])
 Matrix{T}(::Z) where {T} = Matrix{T}([1 0; 0 -1])
 Matrix{T}(::H) where {T} = Matrix{T}([1 1; 1 -1] ./ sqrt(2))
 Matrix{T}(::S) where {T} = Matrix{T}([1 0; 0 1im])

--- a/src/Array.jl
+++ b/src/Array.jl
@@ -194,6 +194,7 @@ Array{T}(op::Op) where {T,Op<:Control} = Array{T,2 * length(Op)}(op)
 Array{T,N}(op::Control) where {T,N} = Array{T,N}(reshape(Matrix{T}(op), fill(2, N)...))
 
 Array{T}(op::SU{N}) where {T,N} = Array{T,2N}(reshape(Matrix{T}(op), fill(2, 2N)...))
+Array{T,M}(op::SU{N}) where {T,N,M} = (M == 2*N) ?  Array{T,2N}(reshape(Matrix{T}(op), fill(2, 2N)...)) : throw(ArgumentError("Invalid dimensions"))
 
 # diagonal matrices
 # NOTE efficient multiplication due to no memory swap needed: plain element-wise multiplication

--- a/test/Array_test.jl
+++ b/test/Array_test.jl
@@ -226,7 +226,7 @@
             @test begin
                 op = Ryy(; θ = π)
                 y = Matrix(Y())
-                Matrix(op) ≈ 1im * reshape(permutedims(reshape(kron(vec(y), vec(y)), 2, 2, 2, 2), (1, 3, 2, 4)), 4, 4)
+                Matrix(op) ≈ -1im * kron(y, y)
             end
         end
 


### PR DESCRIPTION
### Summary
This PR fixes the `Matrix` value of the `Y` gate, as discussed in [Tenet.jl/issues/210](https://github.com/bsc-quantic/Tenet.jl/issues/210).

So now:
```julia
julia> using Yao; using Quac

julia> mat(Yao.Y)
2×2 LuxurySparse.SDPermMatrix{ComplexF64, Int64, Vector{ComplexF64}, Vector{Int64}}:
 0.0+0.0im  0.0-1.0im
 0.0+1.0im  0.0+0.0im

julia> Matrix(Quac.Y())
2×2 Matrix{ComplexF64}:
 0.0+0.0im  0.0-1.0im
 0.0+1.0im  0.0+0.0im
```